### PR TITLE
Improve wiremock pattern matching

### DIFF
--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionServiceTest.java
@@ -45,9 +45,12 @@ class ContributionServiceTest {
 	@Test
 	void testXMLValid() throws JAXBException {
 		when(contributionsMapperUtilsMock.generateFileXML(any(), any())).thenReturn("ValidXML");
-		contributionService.processDailyFiles();
+		when(contributionsMapperUtilsMock.generateFileName(any())).thenReturn("TestFilename.xml");
+		when(contributionsMapperUtilsMock.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
+		boolean result = contributionService.processDailyFiles();
 		verify(contributionsMapperUtilsMock,times(2)).mapLineXMLToObject(any());
 		verify(contributionsMapperUtilsMock).generateFileXML(any(), any());
+		softly.assertThat(result).isTrue();
 	}
 
 	@Test
@@ -61,7 +64,6 @@ class ContributionServiceTest {
 		// failure to generate the xml should return a null xmlString.
 		verify(contributionsMapperUtilsMock).generateFileXML(any(), any());
 		// failure should be the result of file generation
-//		softly.assertThat(result).isFalse();
 
 
 

--- a/dces-drc-integration/src/test/resources/mappings/contributionsPutStubs.json
+++ b/dces-drc-integration/src/test/resources/mappings/contributionsPutStubs.json
@@ -7,7 +7,7 @@
         "method": "POST",
         "bodyPatterns": [
           {
-            "matches": ".*ValidXML.*"
+            "contains": "{\"recordsSent\":2,\"xmlContent\":\"ValidXML\",\"concorContributionIds\":[\"1234\",\"9876\"],\"xmlFileName\":\"TestFilename.xml\",\"ackXmlContent\":\"ValidAckXML\"}"
           }
         ]
       },


### PR DESCRIPTION


## What
Updating ContributionServiceTest valid scenario test to match only a successfully formed body.
This means should any changes to process to form the json, it should break this test. As it should.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
