### PR TITLE
DCES-268 - Add Fdc Global Update to service

### DIFF
--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClient.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClient.java
@@ -13,6 +13,7 @@ import uk.gov.justice.laa.crime.dces.integration.maatapi.MaatApiClientFactory;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.client.MaatApiClient;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.model.contributions.ConcurContribEntry;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.model.fdc.FdcContributionsResponse;
+import uk.gov.justice.laa.crime.dces.integration.maatapi.model.fdc.FdcGlobalUpdateResponse;
 import uk.gov.justice.laa.crime.dces.integration.model.ContributionPutRequest;
 
 import java.util.List;
@@ -23,12 +24,16 @@ public interface ContributionClient extends MaatApiClient {
     @GetExchange("/concor-contribution-files")
     List<ConcurContribEntry> getContributions(@RequestParam String status);
 
-    @GetExchange("/fdc-contribution-files")
-    FdcContributionsResponse getFdcContributions(@RequestParam String status);
-
     @PostExchange("/create-contribution-file")
     @Valid
     Boolean updateContributions(@RequestBody ContributionPutRequest contributionPutRequest);
+
+    @PostExchange("/prepare-fdc-contributions-files")
+    FdcGlobalUpdateResponse executeFdcGlobalUpdate();
+
+
+    @GetExchange("/fdc-contribution-files")
+    FdcContributionsResponse getFdcContributions(@RequestParam String status);
 
     @Configuration
     class ContributionFilesClientFactory {

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/model/fdc/FdcGlobalUpdateResponse.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/model/fdc/FdcGlobalUpdateResponse.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class FdcGlobalUpdateResponse {
         private boolean successful;
-        int numberOfUpdates;
+        private int numberOfUpdates;
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/model/fdc/FdcGlobalUpdateResponse.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/model/fdc/FdcGlobalUpdateResponse.java
@@ -1,0 +1,15 @@
+package uk.gov.justice.laa.crime.dces.integration.maatapi.model.fdc;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FdcGlobalUpdateResponse {
+        private boolean successful;
+        int numberOfUpdates;
+}

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
@@ -127,8 +127,8 @@ public class FdcService implements FileService{
         try {
             return contributionClient.executeFdcGlobalUpdate();
         }
-        catch (WebClientResponseException e){
-            log.error("Fdc Gloabl Update threw an exception");
+        catch (HttpServerErrorException e){
+            log.error("Fdc Global Update threw an exception");
             throw e;
         }
     }

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/FdcServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/FdcServiceTest.java
@@ -1,6 +1,8 @@
 package uk.gov.justice.laa.crime.dces.integration.service;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -15,6 +17,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.ObjectFactory;
 import uk.gov.justice.laa.crime.dces.integration.utils.FdcMapperUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -38,17 +44,50 @@ class FdcServiceTest {
 	@AfterEach
 	void afterTestAssertAll(){
 		softly.assertAll();
+		for(StubMapping stub: customStubs ){
+			WireMock.removeStub(stub);
+		}
 	}
+
+	private static final List<StubMapping> customStubs = new ArrayList<>();
 
 	@Test
 	void testXMLValid() {
+		// setup
 		ObjectFactory of = new ObjectFactory();
 		when(fdcMapperUtils.generateFileXML(any())).thenReturn("ValidXML");
 		when(fdcMapperUtils.mapFdcEntry(any())).thenReturn(of.createFdcFileFdcListFdc());
+		// run
 		boolean successful = fdcService.processDailyFiles();
+		// test
 		verify(fdcMapperUtils).generateFileXML(any());
 		verify(fdcMapperUtils,times(12)).mapFdcEntry(any());
 		softly.assertThat(successful).isTrue();
+		WireMock.verify(1, getRequestedFor(urlEqualTo("/debt-collection-enforcement/fdc-contribution-files?status=REQUESTED")));
+		WireMock.verify(1, postRequestedFor(urlEqualTo("/debt-collection-enforcement/prepare-fdc-contributions-files")));
+	}
+
+	@Test
+	void testFdcGlobalUpdateFail(){
+		// setup
+		ObjectFactory of = new ObjectFactory();
+		when(fdcMapperUtils.generateFileXML(any())).thenReturn(null);
+		when(fdcMapperUtils.mapFdcEntry(any())).thenReturn(of.createFdcFileFdcListFdc());
+		customStubs.add(stubFor(get("/debt-collection-enforcement/prepare-fdc-contributions-files").atPriority(1)
+				.willReturn(ok("""
+						{
+						          "successful": false,
+						          "numberOfUpdates": 0
+						        }
+						"""))));
+		// run
+		boolean successful = fdcService.processDailyFiles();
+		// test
+		verify(fdcMapperUtils).generateFileXML(any());
+		verify(fdcMapperUtils,times(12)).mapFdcEntry(any());
+		softly.assertThat(successful).isFalse();
+		WireMock.verify(1, postRequestedFor(urlEqualTo("/debt-collection-enforcement/prepare-fdc-contributions-files")));
+		WireMock.verify(0, getRequestedFor(urlEqualTo("/debt-collection-enforcement/fdc-contribution-files")));
 	}
 
 }

--- a/dces-drc-integration/src/test/resources/mappings/fdcGetStubs.json
+++ b/dces-drc-integration/src/test/resources/mappings/fdcGetStubs.json
@@ -2,6 +2,7 @@
   "mappings": [
     {
       "scenarioName": "successBasicRequest",
+      "priority": 999,
       "request": {
         "urlPath": "/debt-collection-enforcement/fdc-contribution-files",
         "queryParameters": {

--- a/dces-drc-integration/src/test/resources/mappings/fdcGlobalUpdateStubs.json
+++ b/dces-drc-integration/src/test/resources/mappings/fdcGlobalUpdateStubs.json
@@ -17,27 +17,6 @@
           "numberOfUpdates": 3
         }
       }
-    },
-    {
-      "scenarioName": "FailedBasicRequest",
-      "request": {
-        "urlPath": "/debt-collection-enforcement/fdc-contribution-files",
-        "queryParameters": {
-          "status": {
-            "equalTo": "500ERROR"
-          }
-        },
-        "method": "GET"
-      },
-      "response": {
-        "status": 500,
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "jsonBody": {
-          "files": []
-        }
-      }
     }
   ]
 }

--- a/dces-drc-integration/src/test/resources/mappings/fdcGlobalUpdateStubs.json
+++ b/dces-drc-integration/src/test/resources/mappings/fdcGlobalUpdateStubs.json
@@ -1,0 +1,44 @@
+{
+  "mappings": [
+    {
+      "scenarioName": "successBasicRequest",
+      "priority": 999,
+      "request": {
+        "urlPath": "/debt-collection-enforcement/prepare-fdc-contributions-files",
+        "method": "POST"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "successful": true,
+          "numberOfUpdates": 3
+        }
+
+      }
+    },
+    {
+      "scenarioName": "FailedBasicRequest",
+      "request": {
+        "urlPath": "/debt-collection-enforcement/fdc-contribution-files",
+        "queryParameters": {
+          "status": {
+            "equalTo": "500ERROR"
+          }
+        },
+        "method": "GET"
+      },
+      "response": {
+        "status": 500,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "files": []
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-268)
Adding the Fdc Global Update endpoint to the main service. Tests have been made for both when the global update is successful, and failing. Mapping updated due to being unable to directly use fdc object ( naming issues ).

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
