### PR TITLE
DCES-318 Global Update non-blocking

### DIFF
--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/MaatApiClientFactory.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/MaatApiClientFactory.java
@@ -15,7 +15,7 @@ public class MaatApiClientFactory {
     @Bean
     public static <T extends MaatApiClient> T maatApiClient(WebClient maatApiWebClient, Class<T> returnClass) {
         HttpServiceProxyFactory httpServiceProxyFactory =
-                HttpServiceProxyFactory.builder(WebClientAdapter.forClient(maatApiWebClient))
+                HttpServiceProxyFactory.builderFor(WebClientAdapter.create(maatApiWebClient))
                         .build();
         return httpServiceProxyFactory.createClient(returnClass);
     }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-318)

Changed the logic for the fdc service to log errors, and failures of the global update call, but continue on. 
This is due to there being other ways that valid FDCs can be made ready, not just with the global update. 
This will allow those kinds to be processed timely.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
