### PR TITLE
Use SoftAssertions as in the Contributions integration test (really just checking GH perms OK)

### DIFF
--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcIntegrationTest.java
@@ -48,7 +48,7 @@ class FdcIntegrationTest {
 				.fdcId(31774046)
 				.build();
 		String response = fdcService.processFdcUpdate(dataRequest);
-		assertEquals("The request has been processed successfully", response);
+		softly.assertThat(response).isEqualTo("The request has been processed successfully");
 	}
 
 	@Test
@@ -59,7 +59,7 @@ class FdcIntegrationTest {
 				.errorText(errorText)
 				.build();
 		String response = fdcService.processFdcUpdate(dataRequest);
-		assertEquals("The request has failed to process", response);
+		softly.assertThat(response).isEqualTo("The request has failed to process");
 	}
 
 }


### PR DESCRIPTION
## What

A very minor, but probably valid, change to confirm that I can both push and create PRs in the repository.

Made the `FdcIntegrationTest` class use `SoftAssertions` from AssertJ, like the `ContributionIntegrationTest` class does. In fact, this change won't make any immediate difference as there's only one assertion in each test method anyway (as there was in the other integration test class too).

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
