### PR TITLE
DCES-333 pre-requisites for first functional tests

### DIFF
--- a/dces-drc-integration/build.gradle
+++ b/dces-drc-integration/build.gradle
@@ -63,6 +63,12 @@ configurations {
 	integrationTestImplementation.extendsFrom testImplementation
 	integrationTestImplementation.extendsFrom testCompile
 	integrationTestImplementation.extendsFrom testRuntime
+	integrationTestCompileOnly {
+		extendsFrom testCompileOnly
+	}
+	integrationTestAnnotationProcessor {
+		extendsFrom testAnnotationProcessor
+	}
 }
 
 
@@ -117,6 +123,8 @@ dependencies {
 	testImplementation "com.github.tomakehurst:wiremock-jre8-standalone:$versions.wiremockVersion"
 	testImplementation "com.squareup.okhttp3:mockwebserver:$versions.mockwebserverVersion"
 
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 jacoco {

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
@@ -13,7 +13,7 @@ import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateConcorCont
 
 import java.util.List;
 
-@HttpExchange("/test-data/debt-collection-enforcement")
+@HttpExchange("/debt-collection-enforcement/test-data")
 public interface TestDataClient extends MaatApiClient {
     @PutExchange("/concor-contribution-status")
     @Valid

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.laa.crime.dces.integration.client;
+
+import jakarta.validation.Valid;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PutExchange;
+import uk.gov.justice.laa.crime.dces.integration.maatapi.MaatApiClientFactory;
+import uk.gov.justice.laa.crime.dces.integration.maatapi.client.MaatApiClient;
+import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateConcorContributionStatusRequest;
+
+import java.util.List;
+
+@HttpExchange("/test-data/debt-collection-enforcement")
+public interface TestDataClient extends MaatApiClient {
+    @PutExchange("/concor-contribution-status")
+    @Valid
+    List<Long> updateConcurContributionStatus(@RequestBody UpdateConcorContributionStatusRequest updateConcorContributionStatusRequest);
+
+    @Configuration
+    class TestDataClientFactory {
+
+        @Bean
+        public TestDataClient getTestDataClient(WebClient maatApiWebClient) {
+            return MaatApiClientFactory.maatApiClient(maatApiWebClient, TestDataClient.class);
+        }
+    }
+
+}

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/model/external/ConcorContributionStatus.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/model/external/ConcorContributionStatus.java
@@ -1,0 +1,7 @@
+package uk.gov.justice.laa.crime.dces.integration.model.external;
+
+public enum ConcorContributionStatus {
+    ACTIVE,
+    SENT,
+    REPLACED
+}

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/model/external/UpdateConcorContributionStatusRequest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/model/external/UpdateConcorContributionStatusRequest.java
@@ -1,0 +1,15 @@
+package uk.gov.justice.laa.crime.dces.integration.model.external;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateConcorContributionStatusRequest {
+    private ConcorContributionStatus status;
+    private int recordCount;
+}

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionIntegrationTest.java
@@ -4,13 +4,19 @@ import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
+import uk.gov.justice.laa.crime.dces.integration.client.TestDataClient;
+import uk.gov.justice.laa.crime.dces.integration.model.external.ConcorContributionStatus;
+import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateConcorContributionStatusRequest;
 import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateLogContributionRequest;
+
+import java.util.List;
 
 
 @EnabledIf(expression = "#{environment['sentry.environment'] == 'development'}", loadContext = true)
@@ -25,6 +31,9 @@ class ContributionIntegrationTest {
 
 	@Autowired
 	private ContributionService contributionService;
+
+	@Autowired
+	private TestDataClient testDataClient;
 
 	@AfterEach
 	void assertAll(){
@@ -52,6 +61,16 @@ class ContributionIntegrationTest {
 				.build();
 		String response = contributionService.processContributionUpdate(dataRequest);
 		softly.assertThat(response).isEqualTo("The request has been processed successfully");
+	}
+
+	@Test @Disabled("This test currently fails until Cognito auth in maat-api is fixed")
+	void testOneContributionStatusChanges() {
+		UpdateConcorContributionStatusRequest dataRequest = UpdateConcorContributionStatusRequest.builder()
+				.status(ConcorContributionStatus.ACTIVE)
+				.recordCount(1)
+				.build();
+		List<Long> response = testDataClient.updateConcurContributionStatus(dataRequest);
+		softly.assertThat(response).hasSize(1);
 	}
 
 }


### PR DESCRIPTION
## What

* Modified `build.gradle` to allow Lombok in both `test` and `integrationTest` tests
* Added simple `TestDataClient` interface for generated client to the DCES test-data services in maat-api
* Added model (dto) classes for the update-status test-data service
* Added a (disabled for now) integration test method (will be extended to a full test case in time)
* Changed the URL prefix for test-data services in the maat-cd-api.

[As a Developer I want to add Test Scenarios for the Contribution Use Cases for the Service](https://dsdmoj.atlassian.net/browse/DCES-333)

These are some pre-requisite changes to get up-and-running with DCES-333 and its sub-tickets (e.g. DCES-349).

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
