### PR TITLE
DCES-349 updated testdata client, and first integration test

### DIFF
--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
@@ -3,12 +3,15 @@ package uk.gov.justice.laa.crime.dces.integration.client;
 import jakarta.validation.Valid;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PutExchange;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.MaatApiClientFactory;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.client.MaatApiClient;
+import uk.gov.justice.laa.crime.dces.integration.model.external.ConcorContributionResponseDTO;
 import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateConcorContributionStatusRequest;
 
 import java.util.List;
@@ -17,7 +20,11 @@ import java.util.List;
 public interface TestDataClient extends MaatApiClient {
     @PutExchange("/concor-contribution-status")
     @Valid
-    List<Long> updateConcurContributionStatus(@RequestBody UpdateConcorContributionStatusRequest updateConcorContributionStatusRequest);
+    List<Integer> updateConcurContributionStatus(@RequestBody UpdateConcorContributionStatusRequest updateConcorContributionStatusRequest);
+
+    @GetExchange("/concor-contribution/{id}")
+    @Valid
+    ConcorContributionResponseDTO getConcorContribution(@PathVariable Integer id);
 
     @Configuration
     class TestDataClientFactory {

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
@@ -20,7 +20,7 @@ import java.util.List;
 public interface TestDataClient extends MaatApiClient {
     @PutExchange("/concor-contribution-status")
     @Valid
-    List<Integer> updateConcurContributionStatus(@RequestBody UpdateConcorContributionStatusRequest updateConcorContributionStatusRequest);
+    List<Integer> updateConcorContributionStatus(@RequestBody UpdateConcorContributionStatusRequest updateConcorContributionStatusRequest);
 
     @GetExchange("/concor-contribution/{id}")
     @Valid

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/model/external/ConcorContributionResponseDTO.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/model/external/ConcorContributionResponseDTO.java
@@ -1,0 +1,30 @@
+package uk.gov.justice.laa.crime.dces.integration.model.external;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConcorContributionResponseDTO {
+
+    @NotBlank
+    private Integer id;
+    private Integer repId;
+    private LocalDate dateCreated;
+    private String userCreated;
+    private LocalDate dateModified;
+    private String userModified;
+    private Integer seHistoryId;
+    @NotBlank
+    private ConcorContributionStatus status;
+    private Integer contribFileId;
+    private Integer ackFileId;
+    private String ackCode;
+}

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionIntegrationTest.java
@@ -4,19 +4,32 @@ import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
+import uk.gov.justice.laa.crime.dces.integration.client.ContributionClient;
+import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
 import uk.gov.justice.laa.crime.dces.integration.client.TestDataClient;
+import uk.gov.justice.laa.crime.dces.integration.controller.DrcStubRestController;
+import uk.gov.justice.laa.crime.dces.integration.maatapi.model.contributions.ConcurContribEntry;
+import uk.gov.justice.laa.crime.dces.integration.model.ContributionUpdateRequest;
+import uk.gov.justice.laa.crime.dces.integration.model.SendContributionFileDataToDrcRequest;
+import uk.gov.justice.laa.crime.dces.integration.model.external.ConcorContributionResponseDTO;
 import uk.gov.justice.laa.crime.dces.integration.model.external.ConcorContributionStatus;
 import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateConcorContributionStatusRequest;
 import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateLogContributionRequest;
 
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 
 @EnabledIf(expression = "#{environment['sentry.environment'] == 'development'}", loadContext = true)
@@ -28,12 +41,20 @@ class ContributionIntegrationTest {
 	@InjectSoftAssertions
 	private SoftAssertions softly;
 
-
 	@Autowired
 	private ContributionService contributionService;
 
 	@Autowired
 	private TestDataClient testDataClient;
+
+	@SpyBean
+	private ContributionClient contributionClientSpy;
+
+	@SpyBean
+	private DrcClient drcClientSpy;
+
+	@SpyBean
+	private DrcStubRestController drcStubRestControllerSpy;
 
 	@AfterEach
 	void assertAll(){
@@ -63,14 +84,86 @@ class ContributionIntegrationTest {
 		softly.assertThat(response).isEqualTo("The request has been processed successfully");
 	}
 
-	@Test @Disabled("This test currently fails until Cognito auth in maat-api is fixed")
-	void testOneContributionStatusChanges() {
-		UpdateConcorContributionStatusRequest dataRequest = UpdateConcorContributionStatusRequest.builder()
-				.status(ConcorContributionStatus.ACTIVE)
-				.recordCount(1)
-				.build();
-		List<Long> response = testDataClient.updateConcurContributionStatus(dataRequest);
-		softly.assertThat(response).hasSize(1);
+	@Test
+	void testPositiveActiveContributionProcessing() {
+		// Set 3 concor_contributions rows to status ACTIVE
+		var request = UpdateConcorContributionStatusRequest.builder().status(ConcorContributionStatus.ACTIVE).recordCount(3).build();
+		var idList = testDataClient.updateConcurContributionStatus(request); // REST call
+		softly.assertThat(idList).hasSize(3);
+
+		// After processDailyFiles() is called, contribSet will contain the set of contribution IDs returned by the call to getContributions.
+		final var contribSet = new TreeSet<Integer>();
+		when(contributionClientSpy.getContributions("ACTIVE")).thenAnswer(invocation -> {
+			var entries = (List<ConcurContribEntry>) invocation.callRealMethod();
+			var activeSet = entries.stream().map(ConcurContribEntry::getConcorContributionId).collect(Collectors.toSet());
+			contribSet.addAll(activeSet);
+			// could change this to only return three entries?
+			return entries;
+		});
+
+		// After processDailyFiles() is called, these sets will contain the set of contribution IDs sent to the DRC.
+		final var sentSet = new TreeSet<Integer>();
+		final var successfullySentSet = new TreeSet<Integer>();
+		when(drcClientSpy.sendContributionUpdate(any())).thenAnswer(invocation -> {
+			var data = (SendContributionFileDataToDrcRequest) invocation.getArgument(0);
+			sentSet.add(data.getContributionId());
+			var result = (Boolean) invocation.callRealMethod();
+			if (Boolean.TRUE.equals(result)) { // note because of the next block, this is likely always true.
+				successfullySentSet.add(data.getContributionId());
+			}
+			return result;
+		});
+
+		// After processDailyFiles() is called, these sets will contain the set of contribution IDs received by the DRC.
+		final var recvSet = new TreeSet<Integer>();
+		when(drcStubRestControllerSpy.contribution(any())).thenAnswer(invocation -> {
+			var data = (SendContributionFileDataToDrcRequest) invocation.getArgument(0);
+			recvSet.add(data.getContributionId());
+			var result = (Boolean) invocation.callRealMethod(); // always return true for our "blessed" rows.
+			return idList.contains(data.getContributionId()) ? Boolean.TRUE : result;
+		});
+
+		// After processDailyFiles() is called, file will contain valid information.
+        final var file = new Object() {
+			Set<Integer> successfullySentSet;
+			int successfullySentCount;
+			String name;
+			Boolean result;
+        };
+		when(contributionClientSpy.updateContributions(any())).thenAnswer(invocation -> {
+			var data = (ContributionUpdateRequest) invocation.getArgument(0);
+			file.successfullySentSet = data.getConcorContributionIds().stream().map(Integer::valueOf).collect(Collectors.toSet());
+			file.successfullySentCount = data.getRecordsSent();
+			file.name = data.getXmlFileName();
+			file.result = (Boolean) invocation.callRealMethod();
+			return file.result;
+		});
+
+		// Run processDailyFiles
+		contributionService.processDailyFiles();
+
+		// Check 1: were our 3 updated rows returned by getContributions?
+		softly.assertThatCollection(contribSet).containsAll(idList);
+
+		// Check 2: were our 3 updated rows sent to the DRC, and was there a synchronous positive response?
+		softly.assertThatCollection(sentSet).containsAll(idList);
+		softly.assertThatCollection(successfullySentSet).containsAll(idList);
+		softly.assertThatCollection(recvSet).containsAll(idList);
+
+		// Check 3: were there three successful contributions recorded, did they include our ids, is the name and result valid?
+		softly.assertThat(file.successfullySentCount).isGreaterThanOrEqualTo(3);
+		softly.assertThatCollection(file.successfullySentSet).containsAll(idList);
+		softly.assertThat(file.name).isNotBlank();
+		softly.assertThat(file.result).isEqualTo(Boolean.TRUE);
+
+		// Check 4: have our 3 updated rows been reset to status SENT
+		for (var id: idList) {
+			ConcorContributionResponseDTO contrib = testDataClient.getConcorContribution(id); // REST call
+			softly.assertThat(contrib.getStatus()).isEqualTo(ConcorContributionStatus.SENT);
+		}
+
+		// Check 5: has a contribution_files row been created>
+		//TODO
 	}
 
 }

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionIntegrationTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
@@ -18,7 +17,6 @@ import org.springframework.test.context.junit.jupiter.EnabledIf;
 import uk.gov.justice.laa.crime.dces.integration.client.ContributionClient;
 import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
 import uk.gov.justice.laa.crime.dces.integration.client.TestDataClient;
-import uk.gov.justice.laa.crime.dces.integration.controller.DrcStubRestController;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.model.contributions.ConcurContribEntry;
 import uk.gov.justice.laa.crime.dces.integration.model.ContributionUpdateRequest;
 import uk.gov.justice.laa.crime.dces.integration.model.SendContributionFileDataToDrcRequest;
@@ -29,7 +27,6 @@ import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateLogContrib
 
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -38,7 +35,7 @@ import static org.mockito.Mockito.mockingDetails;
 
 
 @EnabledIf(expression = "#{environment['sentry.environment'] == 'development'}", loadContext = true)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SpringBootTest
 @ExtendWith(SoftAssertionsExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ContributionIntegrationTest {

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/ContributionProcessSpy.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/ContributionProcessSpy.java
@@ -1,0 +1,91 @@
+package uk.gov.justice.laa.crime.dces.integration.testing;
+
+import lombok.*;
+import uk.gov.justice.laa.crime.dces.integration.client.ContributionClient;
+import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
+import uk.gov.justice.laa.crime.dces.integration.maatapi.model.contributions.ConcurContribEntry;
+import uk.gov.justice.laa.crime.dces.integration.model.ContributionUpdateRequest;
+import uk.gov.justice.laa.crime.dces.integration.model.SendContributionFileDataToDrcRequest;
+import uk.gov.justice.laa.crime.dces.integration.model.external.ConcorContributionResponseDTO;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mockingDetails;
+
+/**
+ * See {@link SpyFactory} for usage details.
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class ContributionProcessSpy {
+    private final List<Integer> updatedIds;       // Returned from maat-api by TestDataClient.updateConcorContributionStatus(...)
+    private final Set<Integer> activeIds;         // Returned from maat-api by ContributionClient.getContributions("ACTIVE")
+    @Singular
+    private final Set<Integer> sentIds;           // Sent to the DRC by DrcClient.sendContributionUpdate(...)
+    private final Set<Integer> xmlCcIds;          // Sent to maat-api by ContributionClient.updateContribution(...)
+    private final int recordsSent;                //  "    "    "
+    private final String xmlContent;              //  "    "    "
+    private final String xmlFileName;             //  "    "    "
+    private final Boolean xmlFileResult;          // Returned from maat-api by ContributionClient.updateContribution(...)
+    @Singular
+    private final List<ConcorContributionResponseDTO> concorContributions; // Returned from maat-api by TestDataClient.getContribution(...)
+    private final String contributionFileContent; // Returned from maat-api by ContributionClient.findContributionFiles(...)
+
+    private static ContributionProcessSpyBuilder builder() {
+        throw new UnsupportedOperationException("Call SpyFactory.newContributionProcessSpyBuilder instead");
+    }
+
+    public static class ContributionProcessSpyBuilder {
+        private final ContributionClient contributionClientSpy;
+        private final DrcClient drcClientSpy;
+
+        private ContributionProcessSpyBuilder() {
+            throw new UnsupportedOperationException("Call SpyFactory.newContributionProcessSpyBuilder instead");
+        }
+
+        ContributionProcessSpyBuilder(final ContributionClient contributionClientSpy, final DrcClient drcClientSpy) {
+            this.contributionClientSpy = contributionClientSpy;
+            this.drcClientSpy = drcClientSpy;
+        }
+
+        public String getXmlFileName() {
+            return xmlFileName;
+        }
+
+        public void instrumentGetContributionsActive() {
+            doAnswer(invocation -> {
+                // Because ContributionClient is a proxied interface, cannot just call `invocation.callRealMethod()` here.
+                // https://github.com/spring-projects/spring-boot/issues/36653
+                @SuppressWarnings("unchecked")
+                final var result = (List<ConcurContribEntry>) mockingDetails(contributionClientSpy).getMockCreationSettings().getDefaultAnswer().answer(invocation);
+                activeIds(result.stream().map(ConcurContribEntry::getConcorContributionId).collect(Collectors.toSet()));
+                return result;
+            }).when(contributionClientSpy).getContributions("ACTIVE");
+        }
+
+        public void instrumentStubbedSendContributionUpdate(Boolean stubbedResult) {
+            doAnswer(invocation -> {
+                sentId(((SendContributionFileDataToDrcRequest) invocation.getArgument(0)).getContributionId());
+                return stubbedResult;
+            }).when(drcClientSpy).sendContributionUpdate(any());
+        }
+
+        public void instrumentUpdateContributions() {
+            doAnswer(invocation -> {
+                final var data = (ContributionUpdateRequest) invocation.getArgument(0);
+                xmlCcIds(data.getConcorContributionIds().stream().map(Integer::valueOf).collect(Collectors.toSet()));
+                recordsSent(data.getRecordsSent());
+                xmlContent(data.getXmlContent());
+                xmlFileName(data.getXmlFileName());
+                final var result = (Boolean) mockingDetails(contributionClientSpy).getMockCreationSettings().getDefaultAnswer().answer(invocation);
+                xmlFileResult(result);
+                return result;
+            }).when(contributionClientSpy).updateContributions(any());
+        }
+    }
+}

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/SpyFactory.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/SpyFactory.java
@@ -1,0 +1,27 @@
+package uk.gov.justice.laa.crime.dces.integration.testing;
+
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.crime.dces.integration.client.ContributionClient;
+import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
+
+/**
+ * Entry-point for working with the ContributionProcessSpy and ContributionProcessSpyBuilder classes (and other spies
+ * as they are developed).
+ * <p>
+ * To use the spy, auto-wire an instance of this factory into your `@SpringBootTest`-annotated test class, call the
+ * method that creates a builder, then call methods on the builder before, or while, the class or method under test
+ * executes. Then call the builder's `build()` method to create a data class which can be used to validate assertions.
+ */
+@Component
+public class SpyFactory {
+    @SpyBean
+    private ContributionClient contributionClientSpy;
+
+    @SpyBean
+    private DrcClient drcClientSpy;
+
+    public ContributionProcessSpy.ContributionProcessSpyBuilder newContributionProcessSpyBuilder() {
+        return new ContributionProcessSpy.ContributionProcessSpyBuilder(contributionClientSpy, drcClientSpy);
+    }
+}

--- a/dces-drc-integration/src/integrationTest/resources/application.yaml
+++ b/dces-drc-integration/src/integrationTest/resources/application.yaml
@@ -49,7 +49,7 @@ services:
     oAuthEnabled: true
     maxBufferSize: 16
   drc-client-api:
-    baseUrl: http://localhost:8089 # don't commit
+    baseUrl: http://localhost:1110
     oAuthEnabled: false
 
 spring:

--- a/dces-drc-integration/src/integrationTest/resources/application.yaml
+++ b/dces-drc-integration/src/integrationTest/resources/application.yaml
@@ -49,7 +49,7 @@ services:
     oAuthEnabled: true
     maxBufferSize: 16
   drc-client-api:
-    baseUrl: http://localhost:1110
+    baseUrl: http://localhost:8089 # don't commit
     oAuthEnabled: false
 
 spring:

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClient.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClient.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.crime.dces.integration.client;
 import jakarta.validation.Valid;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -19,8 +20,8 @@ import uk.gov.justice.laa.crime.dces.integration.model.FdcUpdateRequest;
 import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateLogContributionRequest;
 import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateLogFdcRequest;
 
+import java.time.LocalDate;
 import java.util.List;
-
 
 @HttpExchange("/debt-collection-enforcement")
 public interface ContributionClient extends MaatApiClient {
@@ -41,7 +42,6 @@ public interface ContributionClient extends MaatApiClient {
     @Valid
     Boolean updateFdcs(@RequestBody FdcUpdateRequest contributionPutRequest);
 
-
     @PostExchange("/log-contribution-response")
     @Valid
     Boolean sendLogContributionProcessed(@RequestBody UpdateLogContributionRequest updateLogContributionRequest);
@@ -50,10 +50,20 @@ public interface ContributionClient extends MaatApiClient {
     @Valid
     Boolean sendLogFdcProcessed(@RequestBody UpdateLogFdcRequest updateLogFdcRequest);
 
+    /** For testing only? */
+    @GetExchange("/contributions")
+    @Valid
+    List<String> findContributionFiles(@RequestParam(name = "fromDate") @DateTimeFormat(pattern = "dd.MM.yyyy") final LocalDate fromDate,
+                                       @RequestParam(name = "toDate") @DateTimeFormat(pattern = "dd.MM.yyyy") final LocalDate toDate);
+
+    /** For testing only? */
+    @GetExchange("/final-defence-cost")
+    @Valid
+    List<String> getFdcFiles(@RequestParam(name = "fromDate") @DateTimeFormat(pattern = "dd.MM.yyyy") final LocalDate fromDate,
+                             @RequestParam(name = "toDate") @DateTimeFormat(pattern = "dd.MM.yyyy") final LocalDate toDate);
 
     @Configuration
     class ContributionFilesClientFactory {
-
         @Bean
         public ContributionClient getContributionFilesClient(WebClient maatApiWebClient) {
             return MaatApiClientFactory.maatApiClient(maatApiWebClient, ContributionClient.class);

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
@@ -111,11 +111,11 @@ public class ContributionService implements FileService {
         return fileSentSuccess;
     }
 
-    private Boolean contributionUpdateRequest(String xmlContent, List<String> concurContributionIdList, int numberOfRecords, String fileName, String fileAckXML) throws HttpServerErrorException {
+    private Boolean contributionUpdateRequest(String xmlContent, List<String> concorContributionIdList, int numberOfRecords, String fileName, String fileAckXML) throws HttpServerErrorException {
         ContributionUpdateRequest request = ContributionUpdateRequest.builder()
                 .recordsSent(numberOfRecords)
                 .xmlContent(xmlContent)
-                .concorContributionIds(concurContributionIdList)
+                .concorContributionIds(concorContributionIdList)
                 .xmlFileName(fileName)
                 .ackXmlContent(fileAckXML).build();
         return contributionClient.updateContributions(request);


### PR DESCRIPTION
## What

[DCES-349](https://dsdmoj.atlassian.net/browse/DCES-349)

Integration test that checks that `ContributionService#processDailyFiles()` does the expected orchestration: calling the maat-cd-api before and after calling the third-party DRC.

See the Jira ticket for more details, but for the implementation, the Mockito spying has been moved into a separate class (`ContributionProcessSpy`) to allow it to be reused in multiple integration tests. It is expected a similar `FdcProcessSpy` class will be created to "track" execution of the FDC integration tests.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[DCES-349]: https://dsdmoj.atlassian.net/browse/DCES-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ