### PR TITLE
DCES-379 Change contribution_file client methods to accept Integer return value (not Boolean)

### DIFF
--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
@@ -16,7 +16,7 @@ import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateConcorCont
 
 import java.util.List;
 
-@HttpExchange("/debt-collection-enforcement/test-data")
+@HttpExchange("/debt-collection-enforcement")
 public interface TestDataClient extends MaatApiClient {
     @PutExchange("/concor-contribution-status")
     @Valid

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionIntegrationTest.java
@@ -48,7 +48,7 @@ class ContributionIntegrationTest {
     }
 
     @Test
-    void testProcessContributionUpdateWhenReturnedFalse() {
+    void testProcessContributionUpdateWhenNotFound() {
         String errorText = "The request has failed to process";
         UpdateLogContributionRequest dataRequest = UpdateLogContributionRequest.builder()
                 .concorId(9)
@@ -59,7 +59,7 @@ class ContributionIntegrationTest {
     }
 
     @Test
-    void testProcessContributionUpdateWhenReturnedTrue() {
+    void testProcessContributionUpdateWhenFound() {
         String errorText = "Error Text updated successfully.";
         UpdateLogContributionRequest dataRequest = UpdateLogContributionRequest.builder()
                 .concorId(47959912)
@@ -102,20 +102,21 @@ class ContributionIntegrationTest {
         watched.getConcorContributions().forEach(concorContribution ->
                 softly.assertThat(watched.getXmlContent()).contains("<maat_id>" + concorContribution.getRepId() + "</maat_id>"));
         softly.assertThat(watched.getXmlFileName()).isNotBlank();
-        softly.assertThat(watched.getXmlFileResult()).isEqualTo(Boolean.TRUE);
+        softly.assertThat(watched.getXmlFileResult()).isNotNull();
+        final int contributionFileId = watched.getXmlFileResult();
 
-        checkConcorContributionsAreSent(watched.getConcorContributions(), startDate, endDate);
+        checkConcorContributionsAreSent(watched.getConcorContributions(), startDate, endDate, contributionFileId);
 
         checkContributionFileIsCreated(watched.getContributionFileContent(), startDate, endDate);
         watched.getConcorContributions().forEach(concorContribution ->
                 softly.assertThat(watched.getContributionFileContent()).contains("<maat_id>" + concorContribution.getRepId() + "</maat_id>"));
     }
 
-    private void checkConcorContributionsAreSent(final List<ConcorContributionResponseDTO> concorContributions, final LocalDate startDate, final LocalDate endDate) {
+    private void checkConcorContributionsAreSent(final List<ConcorContributionResponseDTO> concorContributions, final LocalDate startDate, final LocalDate endDate, final int contributionFileId) {
         concorContributions.forEach(concorContribution -> {
             softly.assertThat(concorContribution.getStatus()).isEqualTo(ConcorContributionStatus.SENT);
-            softly.assertThat(concorContribution.getContribFileId()).isNotNull();
-            softly.assertThat(concorContribution.getUserModified()).isEqualTo("TOGDATA"); // actually we should be checking for "DCES"
+            softly.assertThat(concorContribution.getContribFileId()).isEqualTo(contributionFileId);
+            softly.assertThat(concorContribution.getUserModified()).isEqualTo("DCES"); // actually we should be checking for "DCES"
             softly.assertThat(concorContribution.getDateModified()).isBetween(startDate, endDate);
         });
     }

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/ContributionProcessSpy.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/ContributionProcessSpy.java
@@ -31,7 +31,7 @@ public class ContributionProcessSpy {
     private final int recordsSent;                //  "    "    "
     private final String xmlContent;              //  "    "    "
     private final String xmlFileName;             //  "    "    "
-    private final Boolean xmlFileResult;          // Returned from maat-api by ContributionClient.updateContribution(...)
+    private final Integer xmlFileResult;          // Returned from maat-api by ContributionClient.updateContribution(...)
     @Singular
     private final List<ConcorContributionResponseDTO> concorContributions; // Returned from maat-api by TestDataClient.getContribution(...)
     private final String contributionFileContent; // Returned from maat-api by ContributionClient.findContributionFiles(...)
@@ -82,7 +82,7 @@ public class ContributionProcessSpy {
                 recordsSent(data.getRecordsSent());
                 xmlContent(data.getXmlContent());
                 xmlFileName(data.getXmlFileName());
-                final var result = (Boolean) mockingDetails(contributionClientSpy).getMockCreationSettings().getDefaultAnswer().answer(invocation);
+                final var result = (Integer) mockingDetails(contributionClientSpy).getMockCreationSettings().getDefaultAnswer().answer(invocation);
                 xmlFileResult(result);
                 return result;
             }).when(contributionClientSpy).updateContributions(any());

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClient.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClient.java
@@ -30,7 +30,7 @@ public interface ContributionClient extends MaatApiClient {
 
     @PostExchange("/create-contribution-file")
     @Valid
-    Boolean updateContributions(@RequestBody ContributionUpdateRequest contributionUpdateRequest);
+    Integer updateContributions(@RequestBody ContributionUpdateRequest contributionUpdateRequest);
 
     @PostExchange("/prepare-fdc-contributions-files")
     FdcGlobalUpdateResponse executeFdcGlobalUpdate();
@@ -40,15 +40,15 @@ public interface ContributionClient extends MaatApiClient {
 
     @PostExchange("/create-fdc-file")
     @Valid
-    Boolean updateFdcs(@RequestBody FdcUpdateRequest contributionPutRequest);
+    Integer updateFdcs(@RequestBody FdcUpdateRequest contributionPutRequest);
 
     @PostExchange("/log-contribution-response")
     @Valid
-    Boolean sendLogContributionProcessed(@RequestBody UpdateLogContributionRequest updateLogContributionRequest);
+    Integer sendLogContributionProcessed(@RequestBody UpdateLogContributionRequest updateLogContributionRequest);
 
     @PostExchange("/log-fdc-response")
     @Valid
-    Boolean sendLogFdcProcessed(@RequestBody UpdateLogFdcRequest updateLogFdcRequest);
+    Integer sendLogFdcProcessed(@RequestBody UpdateLogFdcRequest updateLogFdcRequest);
 
     /** For testing only? */
     @GetExchange("/contributions")

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/MaatApiWebClientFactory.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/MaatApiWebClientFactory.java
@@ -51,7 +51,7 @@ public class MaatApiWebClientFactory {
                 HttpClient.create(provider)
                     .resolver(DefaultAddressResolverGroup.INSTANCE)
                     .compress(true)
-                    .responseTimeout(Duration.ofSeconds(30))
+                    .responseTimeout(Duration.ofSeconds(90))
                 )
             )
             .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
@@ -87,7 +87,7 @@ public class ContributionService implements FileService {
     private boolean updateContributionsAndCreateFile(Map<String, CONTRIBUTIONS> successfulContributions, Map<String,String> failedContributions){
         // if >1 contribution was sent
         // create xml file
-        Integer contributionFileId = 0;
+        Integer contributionFileId = null;
         if ( Objects.nonNull(successfulContributions) && !successfulContributions.isEmpty() ) {
             // Setup and make MAAT API "ATOMIC UPDATE" REST call below:
             LocalDateTime dateGenerated = LocalDateTime.now();

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
@@ -6,12 +6,14 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.reactive.function.client.WebClientException;
 import uk.gov.justice.laa.crime.dces.integration.client.ContributionClient;
 import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
+import uk.gov.justice.laa.crime.dces.integration.maatapi.exception.MaatApiClientException;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.model.contributions.ConcurContribEntry;
 import uk.gov.justice.laa.crime.dces.integration.model.ContributionUpdateRequest;
-import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateLogContributionRequest;
 import uk.gov.justice.laa.crime.dces.integration.model.SendContributionFileDataToDrcRequest;
+import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateLogContributionRequest;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 import uk.gov.justice.laa.crime.dces.integration.utils.ContributionsMapperUtils;
 
@@ -31,10 +33,11 @@ public class ContributionService implements FileService {
     private final DrcClient drcClient;
 
     public String processContributionUpdate(UpdateLogContributionRequest updateLogContributionRequest) {
-        Boolean response = contributionClient.sendLogContributionProcessed(updateLogContributionRequest);
-        if (response != null && response) {
+        try {
+            contributionClient.sendLogContributionProcessed(updateLogContributionRequest);
             return "The request has been processed successfully";
-        } else {
+        } catch (MaatApiClientException | WebClientException | HttpServerErrorException e) {
+            log.info("processContributionUpdate failed", e);
             return "The request has failed to process";
         }
     }
@@ -84,7 +87,7 @@ public class ContributionService implements FileService {
     private boolean updateContributionsAndCreateFile(Map<String, CONTRIBUTIONS> successfulContributions, Map<String,String> failedContributions){
         // if >1 contribution was sent
         // create xml file
-        boolean fileSentSuccess = false;
+        Integer contributionFileId = 0;
         if ( Objects.nonNull(successfulContributions) && !successfulContributions.isEmpty() ) {
             // Setup and make MAAT API "ATOMIC UPDATE" REST call below:
             LocalDateTime dateGenerated = LocalDateTime.now();
@@ -99,19 +102,19 @@ public class ContributionService implements FileService {
                 log.info("Contributions failed to send: {}", failedContributions.size());
             }
             try {
-                fileSentSuccess = contributionUpdateRequest(xmlFile, successfulIdList, successfulIdList.size(),fileName,ackXml);
+                contributionFileId = contributionUpdateRequest(xmlFile, successfulIdList, successfulIdList.size(),fileName,ackXml);
             }
-            catch (HttpServerErrorException e){
+            catch (MaatApiClientException | WebClientException| HttpServerErrorException e){
                 // If failed, we want to handle this. As it will mean the whole process failed for current day.
                 log.error("Contributions file failed to send! Investigation needed. State of files will be out of sync!");
                 // TODO: Need to figure how we're going to log a failed call to the ATOMIC UPDATE.
                 throw e;
             }
         }
-        return fileSentSuccess;
+        return contributionFileId != null;
     }
 
-    private Boolean contributionUpdateRequest(String xmlContent, List<String> concorContributionIdList, int numberOfRecords, String fileName, String fileAckXML) throws HttpServerErrorException {
+    private Integer contributionUpdateRequest(String xmlContent, List<String> concorContributionIdList, int numberOfRecords, String fileName, String fileAckXML) throws HttpServerErrorException {
         ContributionUpdateRequest request = ContributionUpdateRequest.builder()
                 .recordsSent(numberOfRecords)
                 .xmlContent(xmlContent)

--- a/dces-drc-integration/src/test/resources/mappings/contributionsLogMessagesStubs.json
+++ b/dces-drc-integration/src/test/resources/mappings/contributionsLogMessagesStubs.json
@@ -18,7 +18,7 @@
         "headers": {
           "Content-Type": "application/json"
         },
-        "jsonBody": true
+        "jsonBody": 1111
       }
     },
     {
@@ -35,11 +35,14 @@
         ]
       },
       "response": {
-        "status": 200,
+        "status": 400,
         "headers": {
           "Content-Type": "application/json"
         },
-        "jsonBody": false
+        "jsonBody": {
+          "code": "BAD_REQUEST",
+          "message": "Some message"
+        }
       }
     }
   ]

--- a/dces-drc-integration/src/test/resources/mappings/contributionsPutStubs.json
+++ b/dces-drc-integration/src/test/resources/mappings/contributionsPutStubs.json
@@ -16,7 +16,7 @@
         "headers": {
           "Content-Type": "application/json"
         },
-        "jsonBody": true
+        "jsonBody": 1111
       }
     },
     {

--- a/dces-drc-integration/src/test/resources/mappings/fdcLogMessagesStubs.json
+++ b/dces-drc-integration/src/test/resources/mappings/fdcLogMessagesStubs.json
@@ -18,7 +18,7 @@
         "headers": {
           "Content-Type": "application/json"
         },
-        "jsonBody": true
+        "jsonBody": 1111
       }
     },
     {
@@ -35,11 +35,14 @@
         ]
       },
       "response": {
-        "status": 200,
+        "status": 400,
         "headers": {
           "Content-Type": "application/json"
         },
-        "jsonBody": false
+        "jsonBody": {
+          "code": "BAD_REQUEST",
+          "message": "Some message"
+        }
       }
     }
   ]

--- a/dces-drc-integration/src/test/resources/mappings/fdcPutStubs.json
+++ b/dces-drc-integration/src/test/resources/mappings/fdcPutStubs.json
@@ -17,7 +17,7 @@
         "headers": {
           "Content-Type": "application/json"
         },
-        "jsonBody": true
+        "jsonBody": 1111
       }
     },
     {


### PR DESCRIPTION
## What

[DCES-379](https://dsdmoj.atlassian.net/browse/DCES-379) Change contribution_file client methods to accept Integer (not Boolean)

- Clear up confusion of having both HTTP status error code and a Boolean response body which is only sent with HTTP status 200
- Change the clients to reflect the new return type and error handling
- Update the WireMock JSON mappings to reflect the changed protocol
- Use the contribution_file ID in the integration tests
- Minor: Fix the TestDataClient to use the updated URL prefix
- Minor: Increase the read timeout for maatapi clients to 90 seconds as 30 seconds was insufficient for integration tests (on development env)
- Minor: Catch other exceptions that the maatapi clients can throw

Needed to be able to write some of the tests like DCES-354 and DCES-357, etc.
See also ministryofjustice/laa-maat-court-data-api#993, that should be merged before this.
(Branch name was a typo -should say `379`).

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

[DCES-354]: https://dsdmoj.atlassian.net/browse/DCES-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DCES-379]: https://dsdmoj.atlassian.net/browse/DCES-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ