### PR TITLE
DCES-352 Add integration test for unprocessed ACTIVE concor_contribution

### DIFF
--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/DrcLoggingIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/DrcLoggingIntegrationTest.java
@@ -92,17 +92,17 @@ class DrcLoggingIntegrationTest {
         // Update at least 3 concor_contribution rows to ACTIVE:
         final var updatedIds = spyFactory.updateConcorContributionStatus(ConcorContributionStatus.ACTIVE, 3);
 
-        final ContributionProcessSpy.ContributionProcessSpyBuilder watching = spyFactory.newContributionProcessSpyBuilder();
-        watching.instrumentAndFilterGetContributionsActive(updatedIds); // fake ACTIVE records to just 3 updated
-        watching.instrumentAndStubSendContributionUpdate(Boolean.TRUE); // fake DRC response
-        watching.instrumentUpdateContributions(); // capture contribution_file ID
+        final ContributionProcessSpy.ContributionProcessSpyBuilder watching = spyFactory.newContributionProcessSpyBuilder()
+                .traceAndFilterGetContributionsActive(updatedIds) // fake ACTIVE records to just 3 updated
+                .traceAndStubSendContributionUpdate(id -> Boolean.TRUE) // fake DRC response
+                .traceUpdateContributions(); // capture contribution_file ID
 
         contributionService.processDailyFiles();
 
         final ContributionProcessSpy watched = watching.build();
 
-        final DrcLoggingProcessSpy.DrcLoggingProcessSpyBuilder logging = spyFactory.newDrcLoggingProcessSpyBuilder();
-        logging.instrumentSendLogContributionProcessed();
+        final DrcLoggingProcessSpy.DrcLoggingProcessSpyBuilder logging = spyFactory.newDrcLoggingProcessSpyBuilder()
+                .traceSendLogContributionProcessed();
 
         // Call the fake DRC responses under test:
         final var startDate = LocalDate.now();

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/DrcLoggingProcessSpy.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/DrcLoggingProcessSpy.java
@@ -1,17 +1,14 @@
 package uk.gov.justice.laa.crime.dces.integration.testing;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
 import uk.gov.justice.laa.crime.dces.integration.client.ContributionClient;
-import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
-import uk.gov.justice.laa.crime.dces.integration.maatapi.model.contributions.ConcurContribEntry;
-import uk.gov.justice.laa.crime.dces.integration.model.ContributionUpdateRequest;
-import uk.gov.justice.laa.crime.dces.integration.model.SendContributionFileDataToDrcRequest;
-import uk.gov.justice.laa.crime.dces.integration.model.external.ConcorContributionResponseDTO;
 import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateLogContributionRequest;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -46,7 +43,7 @@ public class DrcLoggingProcessSpy {
             this.contributionClientSpy = contributionClientSpy;
         }
 
-        public void instrumentSendLogContributionProcessed() {
+        public DrcLoggingProcessSpyBuilder traceSendLogContributionProcessed() {
             doAnswer(invocation -> {
                 final var argument = (UpdateLogContributionRequest) invocation.getArgument(0);
                 concorContributionId(argument.getConcorId());
@@ -57,6 +54,7 @@ public class DrcLoggingProcessSpy {
                 contributionFileId(result);
                 return result;
             }).when(contributionClientSpy).sendLogContributionProcessed(any());
+            return this;
         }
     }
 }


### PR DESCRIPTION
## What

[DCES-352](https://dsdmoj.atlassian.net/browse/DCES-352) Add integration test for unprocessed ACTIVE concor_contribution

- Rename the `instrument*` methods to `trace*` in the `*ProcessSpy` classes
- Make the `trace*` methods chainable (which maked sense in a `Builder` class)
- Update the tests that consume the `*ProcessSpy` classes
- Add a new test that an unprocessed ACTIVE concor_contribution is not included in the contribution file, and that its status is not changed to SENT

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[DCES-352]: https://dsdmoj.atlassian.net/browse/DCES-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ