### PR TITLE
DCES-360 Add negative integration test for fdc_contribution status

### DIFF
--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcTestDataCreatorService.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcTestDataCreatorService.java
@@ -86,7 +86,7 @@ public class FdcTestDataCreatorService {
         processNegativeTests(testType, repOrderId, fdcId, -7);
       });
     } else {
-      throw new RuntimeException("No candidate rep orders found for delayed pickup test type " + testType);
+      throw new RuntimeException("No candidate rep orders found for fast track test type " + testType);
     }
     return fdcIds;
   }

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/FdcProcessSpy.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/FdcProcessSpy.java
@@ -29,6 +29,7 @@ import static uk.gov.justice.laa.crime.dces.integration.service.FdcService.REQUE
 @Builder
 @Getter
 public class FdcProcessSpy {
+  private final FdcGlobalUpdateResponse globalUpdateResponse;  // Returned from maat-api by FdcClient.executeFdcGlobalUpdate(...)
   private final Set<Integer> requestedIds;      // Returned from maat-api by FdcClient.getFdcContributions("REQUESTED")
   @Singular
   private final Set<Integer> sentIds;           // Sent to the DRC by DrcClient.sendFdcUpdate(...)
@@ -37,7 +38,6 @@ public class FdcProcessSpy {
   private final String xmlContent;              //  "    "    "
   private final String xmlFileName;             //  "    "    "
   private final Integer xmlFileResult;          // Returned from maat-api by FdcClient.updateFdcs(...)
-  private final FdcGlobalUpdateResponse globalUpdateResponse;  // Returned from maat-api by FdcClient.executeFdcGlobalUpdate(...)
 
   private static FdcProcessSpyBuilder builder() {
     throw new UnsupportedOperationException("Call SpyFactory.newFdcProcessSpyBuilder instead");
@@ -54,6 +54,15 @@ public class FdcProcessSpy {
     FdcProcessSpyBuilder(final FdcClient FdcClientSpy, final DrcClient drcClientSpy) {
       this.fdcClientSpy = FdcClientSpy;
       this.drcClientSpy = drcClientSpy;
+    }
+
+    public FdcProcessSpyBuilder traceExecuteFdcGlobalUpdate() {
+      doAnswer(invocation -> {
+        final var result = (FdcGlobalUpdateResponse) mockingDetails(fdcClientSpy).getMockCreationSettings().getDefaultAnswer().answer(invocation);
+        globalUpdateResponse(result);
+        return result;
+      }).when(fdcClientSpy).executeFdcGlobalUpdate();
+      return this;
     }
 
     public FdcProcessSpyBuilder traceAndFilterGetFdcContributions(final Set<Integer> updatedIds) {
@@ -87,15 +96,6 @@ public class FdcProcessSpy {
         xmlFileResult(result);
         return result;
       }).when(fdcClientSpy).updateFdcs(any());
-      return this;
-    }
-
-    public FdcProcessSpyBuilder traceExecuteFdcGlobalUpdate() {
-      doAnswer(invocation -> {
-        final var result = (FdcGlobalUpdateResponse) mockingDetails(fdcClientSpy).getMockCreationSettings().getDefaultAnswer().answer(invocation);
-        globalUpdateResponse(result);
-        return result;
-      }).when(fdcClientSpy).executeFdcGlobalUpdate();
       return this;
     }
   }


### PR DESCRIPTION
## What

[DCES-360](https://dsdmoj.atlassian.net/browse/DCES-360) Add negative integration test for fdc_contribution status

- Fix minor typo in test data creation service exception message
- Re-order member variables and methods in FDC spy (to match call order)
- Add new integration test to check SENT fdc-contributions are not processed

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[DCES-360]: https://dsdmoj.atlassian.net/browse/DCES-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ