### PR TITLE
DCES-361 Add FDC integration test for DRC processing failure

### DIFF
--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionIntegrationTest.java
@@ -45,23 +45,23 @@ class ContributionIntegrationTest {
 
     @Test
     void testProcessContributionUpdateWhenNotFound() {
-        String errorText = "The request has failed to process";
-        UpdateLogContributionRequest dataRequest = UpdateLogContributionRequest.builder()
+        final String errorText = "The request has failed to process";
+        final var updateLogContributionRequest = UpdateLogContributionRequest.builder()
                 .concorId(9)
                 .errorText(errorText)
                 .build();
-        String response = contributionService.processContributionUpdate(dataRequest);
+        final String response = contributionService.processContributionUpdate(updateLogContributionRequest);
         softly.assertThat(response).isEqualTo("The request has failed to process");
     }
 
     @Test
     void testProcessContributionUpdateWhenFound() {
-        String errorText = "Error Text updated successfully.";
-        UpdateLogContributionRequest dataRequest = UpdateLogContributionRequest.builder()
+        final String errorText = "Error Text updated successfully.";
+        final var updateLogContributionRequest = UpdateLogContributionRequest.builder()
                 .concorId(47959912)
                 .errorText(errorText)
                 .build();
-        String response = contributionService.processContributionUpdate(dataRequest);
+        final String response = contributionService.processContributionUpdate(updateLogContributionRequest);
         softly.assertThat(response).isEqualTo("The request has been processed successfully");
     }
 


### PR DESCRIPTION
## What

[DCES-361](https://dsdmoj.atlassian.net/browse/DCES-361) Add FDC integration test for DRC processing failure

- Add integration test for when FDC contributions fail to process with the DRC synchronously
- Refactor to Java 17 the 'legacy/POC' integration tests
- Rename the previous integration test to more sensible name

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[DCES-361]: https://dsdmoj.atlassian.net/browse/DCES-361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ