### PR TITLE
DCES-421: Enable SOD update to null

### DIFF
--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/client/TestDataClient.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.dces.integration.client;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import java.util.Map;
 import java.util.Set;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -56,6 +57,10 @@ public interface TestDataClient extends MaatApiClient {
     @PutExchange("/assessment/rep-orders")
     @Valid
     void updateRepOrderSentenceOrderDate(@RequestBody UpdateRepOrder updateRepOrder);
+
+    @PatchExchange("/assessment/rep-orders/{repId}")
+    @Valid
+    void updateRepOrderSentenceOrderDateToNull(@PathVariable Integer repId, @RequestBody Map<String, Object> repOrder);
 
     @PostExchange("/debt-collection-enforcement/fdc-contribution")
     @Valid

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcTestDataCreatorService.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcTestDataCreatorService.java
@@ -72,7 +72,7 @@ public class FdcTestDataCreatorService {
     final var fdcIds = new HashSet<Integer>();
     if (repOrderIds != null && !repOrderIds.isEmpty()) {
       repOrderIds.forEach(repOrderId -> {
-        testDataClient.updateRepOrderSentenceOrderDate(UpdateRepOrder.builder().repId(repOrderId).sentenceOrderDate(LocalDate.now().plusMonths(-3)).build());
+        testDataClient.updateRepOrderSentenceOrderDate(UpdateRepOrder.builder().repId(repOrderId).sentenceOrderDate(LocalDate.now().minusMonths(3)).build());
         final String manualAcceleration = (fdcAccelerationType == FdcAccelerationType.POSITIVE) ? "Y" : null;
         final int fdcId = testDataClient.createFdcContribution(new CreateFdcContributionRequest(repOrderId, "Y", "Y", manualAcceleration, WAITING_ITEMS)).getId();
         fdcIds.add(fdcId);
@@ -105,7 +105,7 @@ public class FdcTestDataCreatorService {
             testDataClient.updateRepOrderSentenceOrderDateToNull(repOrderId, repOrderWithNullSOD);
           }
           case FAST_TRACK -> testDataClient.updateRepOrderSentenceOrderDate(UpdateRepOrder.builder()
-              .repId(repOrderId).sentenceOrderDate(LocalDate.now().plusMonths(-7)).build());
+              .repId(repOrderId).sentenceOrderDate(LocalDate.now().minusMonths(7)).build());
         }
       }
       case NEGATIVE_CCO -> testDataClient.deleteCrownCourtOutcomes(repOrderId);

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcTestDataCreatorServiceTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcTestDataCreatorServiceTest.java
@@ -86,17 +86,17 @@ class FdcTestDataCreatorServiceTest {
 
     checkRequestAndBody("POST", "/debt-collection-enforcement/fdc-items",
         "{\"fdcId\":1001,\"dateCreated\":\""+getDateAfterMonths(0)+"T00:00:00.000\",\"userCreated\":\"DCES\"}");
-    checkRequestAndBody("PUT", "/assessment/rep-orders", "{\"repId\":1,\"sentenceOrderDate\":\""+getDateAfterMonths(3)+"\"}");
+    checkRequestAndBody("PATCH", "/assessment/rep-orders/1", "{\"sentenceOrderDate\":null}");
     checkRequestAndBody("POST", "/debt-collection-enforcement/fdc-contribution",
         "{\"repId\":2,\"lgfsComplete\":\"Y\",\"agfsComplete\":\"Y\",\"status\":\"WAITING_ITEMS\"}");
     checkRequestAndBody("POST", "/debt-collection-enforcement/fdc-items",
         "{\"fdcId\":1002,\"dateCreated\":\""+getDateAfterMonths(0)+"T00:00:00.000\",\"userCreated\":\"DCES\"}");
-    checkRequestAndBody("PUT", "/assessment/rep-orders", "{\"repId\":2,\"sentenceOrderDate\":\""+getDateAfterMonths(3)+"\"}");
+    checkRequestAndBody("PATCH", "/assessment/rep-orders/2", "{\"sentenceOrderDate\":null}");
     checkRequestAndBody("POST", "/debt-collection-enforcement/fdc-contribution",
         "{\"repId\":3,\"lgfsComplete\":\"Y\",\"agfsComplete\":\"Y\",\"status\":\"WAITING_ITEMS\"}");
     checkRequestAndBody("POST", "/debt-collection-enforcement/fdc-items",
         "{\"fdcId\":1003,\"dateCreated\":\""+getDateAfterMonths(0)+"T00:00:00.000\",\"userCreated\":\"DCES\"}");
-    checkRequestAndBody("PUT", "/assessment/rep-orders", "{\"repId\":3,\"sentenceOrderDate\":\""+getDateAfterMonths(3)+"\"}");
+    checkRequestAndBody("PATCH", "/assessment/rep-orders/3", "{\"sentenceOrderDate\":null}");
   }
 
   @Test
@@ -311,7 +311,6 @@ class FdcTestDataCreatorServiceTest {
 
     private int mockFdcId = 1001;
 
-    public void resetMockFdcId() {mockFdcId = 1001;}
     @SneakyThrows
     @NotNull
     @Override


### PR DESCRIPTION
Use the MAAT API's existing PATCH endpoint to update SOD (Sentence Order Date) to null (to be used in delayed pickup tests).

## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-421)

Use the MAAT API's existing PATCH endpoint to update SOD to null (to be used in delayed pickup tests). This is necessary because the PUT endpoint ignores all null values.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
