### PR TITLE
DCES-411 DCES-412 Negative tests with prev FDC (and fix tests)

### DIFF
--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcIntegrationTest.java
@@ -407,7 +407,7 @@ class FdcIntegrationTest {
 	//TODO: Fix test with implementation of /assessment/ endpoint access.
 	@Disabled("Pending creation of /assessment/ handler")
 	@Test
-	void givenDelayedPickupFdcContributionsWithMissingCCO_whenProcessDailyFilesRuns_thenTheirStatusIsNotUpdated() {
+	void givenDelayedPickupFdcContributionsWithMissingCCO_whenProcessDailyFilesRuns_thenTheyAreNotQueriedNotSentNorInCreatedFile() {
 		final var updatedIds = spyFactory.createFdcDelayedPickupTestData(FdcTestType.NEGATIVE_CCO, 3);
 		CheckOptions checkOptions = CheckOptions.builder().drcStubShouldSucceed(true).updatedIdsShouldBeRequested(false).updatedIdsShouldBeSent(false).contributionFileExpected(false).build();
 		runProcessDailyFilesAndCheckResults(updatedIds, checkOptions, FdcContributionsStatus.WAITING_ITEMS);
@@ -437,10 +437,66 @@ class FdcIntegrationTest {
 	//TODO: Fix test with implementation of /assessment/ endpoint access.
 	@Disabled("Pending creation of /assessment/ handler")
 	@Test
-	void givenFastTrackFdcContributionsWithMissingCCO_whenProcessDailyFilesRuns_thenTheirStatusIsNotUpdated() {
+	void givenFastTrackFdcContributionsWithMissingCCO_whenProcessDailyFilesRuns_thenTheyAreNotQueriedNotSentNorInCreatedFile() {
 		final var updatedIds = spyFactory.createFastTrackTestData(FdcAccelerationType.POSITIVE, FdcTestType.NEGATIVE_CCO, 3);
 		CheckOptions checkOptions = CheckOptions.builder().drcStubShouldSucceed(true).updatedIdsShouldBeRequested(false).updatedIdsShouldBeSent(false).contributionFileExpected(false).build();
 		runProcessDailyFilesAndCheckResults(updatedIds, checkOptions, FdcContributionsStatus.WAITING_ITEMS);
+	}
+
+	/**
+	 * <h4>Scenario:</h4>
+	 * <p>A Negative Test Scenarios for the FDC Service - 'SENT' records do not get processed (Fast tracked pickup).</p>
+	 * <h4>Given:</h4>
+	 * <p>* 3 fdc_contributions records in the SENT status</p>
+	 * <h4>When</h4>
+	 * <p>* The {@link FdcService#processDailyFiles()} method is called</p>
+	 * <h4>Then:</h4>
+	 * <p>1. The call to the callGlobalUpdate is successful i.e. MAAT API returned a successful response
+	 * <p>2. The IDs of the 3 updated records are NOT returned.</p>
+	 * <p>3. The updated IDs are NOT included in the list of IDs returned by the call to retrieve 'REQUESTED' FDC Contributions.</p>
+	 * <p>4. The updated IDs are NOT included in the set of payloads sent to the DRC.</p>
+	 * <p>5. After the `processDailyFiles` method call returns, the fdc_contribution entities corresponding to each
+	 *       of the updated IDs is checked:<br>
+	 *       - Each remains at status SENT<br>
+	 *       - Each has an unpopulated contribution_file ID.</p>
+	 *
+	 * @see <a href="https://dsdmoj.atlassian.net/browse/DCES-412">DCES-412</a> for test specification.
+	 */
+	//TODO: Fix test with implementation of /assessment/ endpoint access.
+	@Disabled("Pending creation of /assessment/ handler")
+	@Test
+	void givenDelayedPickupFdcContributionsWithSentStatus_whenProcessDailyFilesRuns_thenTheyAreNotQueriedNotSentNorInCreatedFile() {
+		final var updatedIds = spyFactory.createFdcDelayedPickupTestData(FdcTestType.NEGATIVE_FDC_STATUS, 3);
+		runProcessDailyFilesAndCheckResults(updatedIds, true, false, false, false, FdcContributionsStatus.SENT);
+	}
+
+	/**
+	 * <h4>Scenario:</h4>
+	 * <p>A negative FDC Contributions test which checks that FDC Contribution records do not get picked up for processing by the Fast Track pickup logic,
+	 * 	if there are no previously sent FDCs.</p>
+	 * <h4>Given:</h4>
+	 * <p>* 3 fdc_contributions record IDs that would normally get picked up by the Fast Track pickup logic,
+	 * 		but there are no previously sent FDCs</p>
+	 * <h4>When</h4>
+	 * <p>* The {@link FdcService#processDailyFiles()} method is called</p>
+	 * <h4>Then:</h4>
+	 * <p>1. The call to the callGlobalUpdate is successful i.e. MAAT API returned a successful response
+	 * <p>2. The IDs of the 3 updated records are NOT returned.</p>
+	 * <p>3. The updated IDs are NOT included in the list of IDs returned by the call to retrieve 'REQUESTED' FDC Contributions.</p>
+	 * <p>4. The updated IDs are NOT included in the set of payloads sent to the DRC.</p>
+	 * <p>5. After the `processDailyFiles` method call returns, the fdc_contribution entities corresponding to each
+	 *       of the updated IDs is checked:<br>
+	 *       - Each remains at status WAITING_ITEMS<br>
+	 *       - Each has an unpopulated contribution_file ID.</p>
+	 *
+	 * @see <a href="https://dsdmoj.atlassian.net/browse/DCES-411">DCES-411</a> for test specification.
+	 */
+	//TODO: Fix test with implementation of /assessment/ endpoint access.
+	@Disabled("Pending creation of /assessment/ handler")
+	@Test
+	void givenFastTrackFdcContributionsWithNoPrevSentFdc_whenProcessDailyFilesRuns_thenTheyAreNotQueriedNotSentNorInCreatedFile() {
+		final var updatedIds = spyFactory.createFastTrackTestData(FdcAccelerationType.PREVIOUS_FDC, FdcTestType.NEGATIVE_PREVIOUS_FDC, 3);
+		runProcessDailyFilesAndCheckResults(updatedIds, true, false, false, false, FdcContributionsStatus.WAITING_ITEMS);
 	}
 
 	/**

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcIntegrationTest.java
@@ -375,7 +375,7 @@ class FdcIntegrationTest {
    * @see <a href="https://dsdmoj.atlassian.net/browse/DCES-406">DCES-406</a> for test specification.
    */
   //TODO: Fix test with implementation of /assessment/ endpoint access.
-  //@Disabled("Pending creation of /assessment/ handler")
+  @Disabled("Pending creation of /assessment/ handler")
   @Test
   void givenSomeFastTrackFdcContributionsWithNullSOD_whenProcessDailyFilesRuns_thenTheyAreNotQueriedNotSentNorInCreatedFile() {
     final var updatedIds = spyFactory.createFastTrackTestData(FdcAccelerationType.POSITIVE, FdcTestType.NEGATIVE_SOD, 3);
@@ -467,7 +467,13 @@ class FdcIntegrationTest {
 	@Test
 	void givenDelayedPickupFdcContributionsWithSentStatus_whenProcessDailyFilesRuns_thenTheyAreNotQueriedNotSentNorInCreatedFile() {
 		final var updatedIds = spyFactory.createFdcDelayedPickupTestData(FdcTestType.NEGATIVE_FDC_STATUS, 3);
-		runProcessDailyFilesAndCheckResults(updatedIds, true, false, false, false, FdcContributionsStatus.SENT);
+
+		final var checkOptions = CheckOptions.builder()
+				.drcStubShouldSucceed(true)
+				.updatedIdsShouldBeRequested(false)
+				.updatedIdsShouldBeSent(false)
+				.contributionFileExpected(false).build();
+		runProcessDailyFilesAndCheckResults(updatedIds, checkOptions, FdcContributionsStatus.SENT);
 	}
 
 	/**
@@ -496,7 +502,13 @@ class FdcIntegrationTest {
 	@Test
 	void givenFastTrackFdcContributionsWithNoPrevSentFdc_whenProcessDailyFilesRuns_thenTheyAreNotQueriedNotSentNorInCreatedFile() {
 		final var updatedIds = spyFactory.createFastTrackTestData(FdcAccelerationType.PREVIOUS_FDC, FdcTestType.NEGATIVE_PREVIOUS_FDC, 3);
-		runProcessDailyFilesAndCheckResults(updatedIds, true, false, false, false, FdcContributionsStatus.WAITING_ITEMS);
+
+		final var checkOptions = CheckOptions.builder()
+				.drcStubShouldSucceed(true)
+				.updatedIdsShouldBeRequested(false)
+				.updatedIdsShouldBeSent(false)
+				.contributionFileExpected(false).build();
+		runProcessDailyFilesAndCheckResults(updatedIds, checkOptions, FdcContributionsStatus.WAITING_ITEMS);
 	}
 
 	/**
@@ -624,5 +636,4 @@ class FdcIntegrationTest {
 			}
 		});
 	}
-
 }

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcTestDataCreatorService.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcTestDataCreatorService.java
@@ -85,6 +85,8 @@ public class FdcTestDataCreatorService {
           testDataClient.createFdcItems(fdcItemBuilder.build());
           fdcItemBuilder = fdcItemBuilder.itemType(FdcItemType.AGFS).adjustmentReason("Pre AGFS Transfer").paidAsClaimed("N").latestCostInd("Current");
         }
+        if (fdcAccelerationType.equals(FdcAccelerationType.PREVIOUS_FDC) && testType.equals(FdcTestType.NEGATIVE_PREVIOUS_FDC))
+          fdcItemBuilder.adjustmentReason("Other");
         testDataClient.createFdcItems(fdcItemBuilder.build());
         processNegativeTests(testType, repOrderId, fdcId, PickupType.FAST_TRACK);
       });

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcTestDataCreatorServiceTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/FdcTestDataCreatorServiceTest.java
@@ -173,7 +173,7 @@ class FdcTestDataCreatorServiceTest {
         "{\"repId\":1,\"lgfsComplete\":\"Y\",\"agfsComplete\":\"Y\",\"manualAcceleration\":\"Y\",\"status\":\"WAITING_ITEMS\"}");
     checkRequestAndBody("POST", "/debt-collection-enforcement/fdc-items",
         "{\"fdcId\":1001,\"dateCreated\":\""+getDateAfterMonths(0)+"T00:00:00.000\",\"userCreated\":\"DCES\"}");
-    checkRequestAndBody("PUT", "/assessment/rep-orders", "{\"repId\":1,\"sentenceOrderDate\":\""+getDateAfterMonths(-7)+"\"}");
+    checkRequestAndBody("PATCH", "/assessment/rep-orders/1", "{\"sentenceOrderDate\":null}");
   }
 
   @Test
@@ -261,7 +261,7 @@ class FdcTestDataCreatorServiceTest {
     checkRequestAndBody("POST", "/debt-collection-enforcement/fdc-contribution",
         "{\"repId\":1,\"lgfsComplete\":\"Y\",\"agfsComplete\":\"Y\",\"status\":\"SENT\"}");
     checkRequestAndBody("POST", "/debt-collection-enforcement/fdc-items",
-        "{\"fdcId\":1001,\"dateCreated\":\""+getDateAfterMonths(0)+"T00:00:00.000\",\"userCreated\":\"DCES\"}");
+        "{\"fdcId\":1001,\"adjustmentReason\":\"Other\",\"dateCreated\":\""+getDateAfterMonths(0)+"T00:00:00.000\",\"userCreated\":\"DCES\"}");
     checkRequestAndBody("PATCH", "/debt-collection-enforcement/fdc-contribution",
         "{\"fdcContributionId\":1001,\"repId\":1,\"previousStatus\":\"SENT\",\"newStatus\":\"WAITING_ITEMS\"}");
   }


### PR DESCRIPTION
## What

[DCES-411](https://dsdmoj.atlassian.net/browse/DCES-411) [DCES-412](https://dsdmoj.atlassian.net/browse/DCES-412) Negative tests with prev FDC

Additional fixes to tests:
- Add `@Disabled` to test that should currently be skipped (`FdcIntegrationTest.givenSomeFastTrackFdcContributionsWithNullSOD_whenProcessDailyFilesRuns_thenTheyAreNotQueriedNotSentNorInCreatedFile()`)
- Change to use PATCH to update SOD was not propagated into the test-data-creator tests

See also #70 (which somehow got confused about the merge direction).

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[DCES-411]: https://dsdmoj.atlassian.net/browse/DCES-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCES-412]: https://dsdmoj.atlassian.net/browse/DCES-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ