### PR TITLE
DCES-505 Use ISO 8601 date strings in JSON API calls to DRC

### DIFF
--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/MaatApiWebClientFactory.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/MaatApiWebClientFactory.java
@@ -46,6 +46,7 @@ public class MaatApiWebClientFactory {
 
     @Bean
     public WebClient maatApiWebClient(
+            WebClient.Builder webClientBuilder,
             ServicesConfiguration servicesConfiguration,
             OAuth2AuthorizedClientManager authorizedClientManager
     ) {
@@ -58,7 +59,7 @@ public class MaatApiWebClientFactory {
                 .evictInBackground(Duration.ofSeconds(120))
                 .build();
 
-        WebClient.Builder clientBuilder = WebClient.builder()
+        webClientBuilder // customize Spring Boot's auto-configured WebClient.Builder bean.
             .baseUrl(servicesConfiguration.getMaatApi().getBaseUrl())
             .filter(addLaaTransactionIdToRequest())
             .filter(logClientResponse())
@@ -82,7 +83,7 @@ public class MaatApiWebClientFactory {
                     servicesConfiguration.getMaatApi().getRegistrationId()
             );
 
-            clientBuilder.filter(oauth2Client);
+            webClientBuilder.filter(oauth2Client);
         }
 
         final ExchangeStrategies strategies = ExchangeStrategies.builder()
@@ -90,9 +91,9 @@ public class MaatApiWebClientFactory {
                 convertMaxBufferSize(servicesConfiguration.getMaatApi().getMaxBufferSize())
                 ))
             .build();
-        clientBuilder.exchangeStrategies(strategies);
+        webClientBuilder.exchangeStrategies(strategies);
 
-        return clientBuilder.build();
+        return webClientBuilder.build();
     }
 
     @Bean

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/DrcApiWebClientConfigurationTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/DrcApiWebClientConfigurationTest.java
@@ -10,6 +10,8 @@ import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.config.ServicesConfiguration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 
@@ -18,6 +20,9 @@ class DrcApiWebClientConfigurationTest {
 
     @Mock
     private ServicesConfiguration servicesConfiguration;
+
+    @Mock
+    private WebClient.Builder webClientBuilder;
 
     @Mock
     private WebClient webClient;
@@ -32,11 +37,15 @@ class DrcApiWebClientConfigurationTest {
     void setUp() {
         when(servicesConfiguration.getDrcClientApi()).thenReturn(drcClientApi);
         when(servicesConfiguration.getDrcClientApi().getBaseUrl()).thenReturn("http://localhost:8080");
+        when(webClientBuilder.baseUrl(anyString())).thenReturn(webClientBuilder);
+        when(webClientBuilder.filter(any())).thenReturn(webClientBuilder);
+        when(webClientBuilder.clientConnector(any())).thenReturn(webClientBuilder);
+        when(webClientBuilder.build()).thenReturn(webClient);
     }
 
     @Test
     void shouldReturnWebClientWhenDrcApiWebClientIsCalled() {
-        WebClient result = drcApiWebClientConfiguration.drcApiWebClient(servicesConfiguration);
+        WebClient result = drcApiWebClientConfiguration.drcApiWebClient(webClientBuilder, servicesConfiguration);
         assertNotNull(result);
     }
 

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/controller/AckFromDrcControllerTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/controller/AckFromDrcControllerTest.java
@@ -32,6 +32,9 @@ class AckFromDrcControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @MockBean
     private TraceService traceService;
 
@@ -56,8 +59,7 @@ class AckFromDrcControllerTest {
         when(contributionService.processContributionUpdate(updateLogContributionRequest)).thenReturn(serviceResponse);
 
         ContributionAckFromDrc contributionAckFromDrc = ContributionAckFromDrc.of(99, "error 99");
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final String requestBody = objectMapper.writeValueAsString(contributionAckFromDrc);
+        final String requestBody = mapper.writeValueAsString(contributionAckFromDrc);
 
         mockMvc.perform(MockMvcRequestBuilders.post(String.format(CONTRIBUTION_URL))
                         .content(requestBody)
@@ -77,8 +79,7 @@ class AckFromDrcControllerTest {
         when(contributionService.processContributionUpdate(updateLogContributionRequest)).thenThrow(serviceResponse);
 
         ContributionAckFromDrc contributionAckFromDrc = ContributionAckFromDrc.of(9, "Failed to process");
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final String requestBody = objectMapper.writeValueAsString(contributionAckFromDrc);
+        final String requestBody = mapper.writeValueAsString(contributionAckFromDrc);
 
         mockMvc.perform(MockMvcRequestBuilders.post(String.format(CONTRIBUTION_URL))
                         .content(requestBody)
@@ -98,8 +99,7 @@ class AckFromDrcControllerTest {
 
         FdcAckFromDrc fdcAckFromDrc = FdcAckFromDrc.of(99, null);
 
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final String requestBody = objectMapper.writeValueAsString(fdcAckFromDrc);
+        final String requestBody = mapper.writeValueAsString(fdcAckFromDrc);
 
         mockMvc.perform(MockMvcRequestBuilders.post(String.format(CONTRIBUTION_FDC_URL))
                         .content(requestBody)
@@ -119,8 +119,7 @@ class AckFromDrcControllerTest {
         when(fdcService.processFdcUpdate(updateLogFdcRequest)).thenThrow(serviceResponse);
 
         FdcAckFromDrc fdcAckFromDrc = FdcAckFromDrc.of(9, "Failed to process");
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final String requestBody = objectMapper.writeValueAsString(fdcAckFromDrc);
+        final String requestBody = mapper.writeValueAsString(fdcAckFromDrc);
 
         mockMvc.perform(MockMvcRequestBuilders.post(String.format(CONTRIBUTION_FDC_URL))
                         .content(requestBody)

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/maatapi/MaatApiWebClientFactoryTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/maatapi/MaatApiWebClientFactoryTest.java
@@ -31,8 +31,12 @@ class MaatApiWebClientFactoryTest {
 
     MaatApiWebClientFactory maatApiWebClientFactory;
     private static MockWebServer mockWebServer;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
+    private WebClient.Builder webClientBuilder;
 
     @Autowired
     private MeterRegistry meterRegistry;
@@ -66,9 +70,7 @@ class MaatApiWebClientFactoryTest {
         expectedResponse.setXmlContent("xmlContent");
         setupValidResponse(expectedResponse);
 
-        WebClient actualWebClient = maatApiWebClientFactory.maatApiWebClient(configuration,
-                authorizedClientManager
-        );
+        WebClient actualWebClient = maatApiWebClientFactory.maatApiWebClient(webClientBuilder, configuration, authorizedClientManager);
 
         assertThat(actualWebClient).isNotNull();
         assertThat(actualWebClient).isInstanceOf(WebClient.class);
@@ -80,7 +82,7 @@ class MaatApiWebClientFactoryTest {
     }
 
     private <T> void setupValidResponse(T returnBody) throws JsonProcessingException {
-        String responseBody = OBJECT_MAPPER.writeValueAsString(returnBody);
+        String responseBody = mapper.writeValueAsString(returnBody);
         mockWebServer.enqueue(new MockResponse()
                 .setResponseCode(HttpStatus.OK.value())
                 .setBody(responseBody)


### PR DESCRIPTION
## What

[DCES-505](https://dsdmoj.atlassian.net/browse/DCES-505) Use ISO 8601 date strings in JSON API calls to DRC
- Avoid `WebClient.builder()`, prefer injected `WebClient.Builder` instance from Spring Boot (which will be auto-configured).
- Avoid `new ObjectMapper()`, prefer injected `ObjectMapper` instance from Spring Boot (which will be auto-configured).
- Configure Jackson serialization to serialize `XMLGregorianCalendar` using `toString()`.

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.


[DCES-505]: https://dsdmoj.atlassian.net/browse/DCES-505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ