### PR TITLE
Separate out Jackson config, NON_NULL contribution records

### DIFF
--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/DrcApiWebClientConfiguration.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/DrcApiWebClientConfiguration.java
@@ -1,11 +1,8 @@
 package uk.gov.justice.laa.crime.dces.integration.config;
 
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.resolver.DefaultAddressResolverGroup;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.boot.ssl.NoSuchSslBundleException;
 import org.springframework.boot.ssl.SslBundle;
 import org.springframework.boot.ssl.SslBundles;
@@ -23,60 +20,70 @@ import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.config.ServicesConfiguration;
 
 import javax.net.ssl.SSLException;
-import javax.xml.datatype.XMLGregorianCalendar;
 import java.time.Duration;
+import java.util.Optional;
 
-@Slf4j
 @Configuration
-@AllArgsConstructor
+@Slf4j
 public class DrcApiWebClientConfiguration {
+    private static final String SSL_BUNDLE_NAME = "client-auth";
 
     @Bean
-    public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
-        // Default serialization of XMLGregorianCalendar calls #toCalendar() to convert it to a Calendar instance, then
-        // serializes that as a number or a full ISO8601 timestamp string (depending on  WRITE_DATES_AS_TIMESTAMPS).
-        // By overriding to use ToStringSerializer, #toString() calls #toXMLFormat(), which takes into account undefined
-        // fields, so does not include the 'T00:00:00Z' time part for dates, for example.
-        return builder -> builder.serializerByType(XMLGregorianCalendar.class, ToStringSerializer.instance);
+    DrcClient drcClient(final WebClient drcApiWebClient) {
+        final HttpServiceProxyFactory httpServiceProxyFactory =
+                HttpServiceProxyFactory.builderFor(WebClientAdapter.create(drcApiWebClient)).build();
+        return httpServiceProxyFactory.createClient(DrcClient.class);
     }
 
-    // keep other tests compiling.
-    public WebClient drcApiWebClient(
-            WebClient.Builder webClientBuilder,
-            ServicesConfiguration servicesConfiguration) {
-        return drcApiWebClient(webClientBuilder, servicesConfiguration, null);
-    }
-
+    /**
+     * Constructs the managed Bean of class `WebClient` in the Spring context used to talk to the DRC API.
+     *
+     * @param webClientBuilder `WebClient.Builder` instance injected by Sprint Boot.
+     * @param servicesConfiguration Our services configuration (used to obtain the DRC API base URL).
+     * @param sslBundles `SslBundles` instance injected by Spring Boot.
+     * @return a configured `WebClient` instance.
+     */
     @Bean
-    public WebClient drcApiWebClient(
-            WebClient.Builder webClientBuilder,
-            ServicesConfiguration servicesConfiguration,
-            SslBundles sslBundles
-    ) {
-        ConnectionProvider provider = ConnectionProvider.builder("custom")
+    public WebClient drcApiWebClient(final WebClient.Builder webClientBuilder,
+                                     final ServicesConfiguration servicesConfiguration,
+                                     final SslBundles sslBundles) {
+        final ConnectionProvider provider = ConnectionProvider.builder("custom")
                 .maxConnections(500)
                 .maxIdleTime(Duration.ofSeconds(20))
                 .maxLifeTime(Duration.ofSeconds(60))
                 .pendingAcquireTimeout(Duration.ofSeconds(60))
                 .evictInBackground(Duration.ofSeconds(120))
                 .build();
-
         return webClientBuilder.clone() // clone Boot's auto-config WebClient.Builder, then add our customizations before build().
                 .baseUrl(servicesConfiguration.getDrcClientApi().getBaseUrl())
-                .clientConnector(
-                        new ReactorClientHttpConnector(
-                                createHttpClient(provider, sslBundles)))
+                .clientConnector(new ReactorClientHttpConnector(createHttpClient(provider, sslBundles)))
                 .build();
     }
 
-    private static HttpClient createHttpClient(ConnectionProvider provider, SslBundles sslBundles) {
+    /**
+     * This method override doesn't create a managed Bean in the Spring context.
+     * It exists to keep the unit tests compiling without adding another required parameter to them all.
+     */
+    public WebClient drcApiWebClient(final WebClient.Builder webClientBuilder,
+                                     final ServicesConfiguration servicesConfiguration) {
+        return drcApiWebClient(webClientBuilder, servicesConfiguration, null);
+    }
+
+    /**
+     * Helper method to generate the netty `HttpClient` for the `WebClient` instance used to talk to the DRC API.
+     *
+     * @param provider Connection provider (specified the connection pooling for clients - if not for this we could have
+     *                 used `webClientBuilder.apply(webClientSsl.fromBundle(clientAuthBundle))` instead of all this.
+     * @param sslBundles Spring Boot's injected set of SSL bundles.
+     * @return a configured `HttpClient` instance ready to use with `WebClient.Builder`.
+     */
+    private static HttpClient createHttpClient(final ConnectionProvider provider, final SslBundles sslBundles) {
         HttpClient httpClient = HttpClient.create(provider);
-        // Handle client-authentication.
-        final SslBundle clientAuthBundle = getClientAuthBundle(sslBundles);
-        if (clientAuthBundle != null) {
+        final Optional<SslBundle> optBundle = getClientAuthBundle(sslBundles);
+        if (optBundle.isPresent()) {
             httpClient = httpClient.secure(spec -> {
-                SslOptions options = clientAuthBundle.getOptions();
-                SslManagerBundle managers = clientAuthBundle.getManagers();
+                SslOptions options = optBundle.get().getOptions();
+                SslManagerBundle managers = optBundle.get().getManagers();
                 SslContextBuilder builder = SslContextBuilder.forClient()
                         .keyManager(managers.getKeyManagerFactory())
                         .trustManager(managers.getTrustManagerFactory())
@@ -95,25 +102,27 @@ public class DrcApiWebClientConfiguration {
                 .responseTimeout(Duration.ofSeconds(30));
     }
 
-    private static SslBundle getClientAuthBundle(SslBundles sslBundles) {
-        SslBundle sslBundle = null;
+    /**
+     * Obtain the SslBundle used for client authentication if it exists.
+     *
+     * @param sslBundles Spring Boot's injected `SslBundles` instance.
+     * @return Optional containing the client authentication SslBundle if it exists.
+     */
+    private static Optional<SslBundle> getClientAuthBundle(final SslBundles sslBundles) {
         if (sslBundles != null) {
             try {
-                sslBundle = sslBundles.getBundle("client-auth");
-                log.info("SSL Bundle 'client-auth' retrieved: {}", sslBundle);
+                final SslBundle sslBundle = sslBundles.getBundle(SSL_BUNDLE_NAME);
+                if (sslBundle == null) { // This is currently unneeded, but in case the API changes in the future.
+                    throw new NoSuchSslBundleException(SSL_BUNDLE_NAME, "getBundle returned null");
+                }
+                log.info("SSL Bundle '{}' retrieved: {}", SSL_BUNDLE_NAME, sslBundle);
+                return Optional.of(sslBundle);
             } catch (NoSuchSslBundleException e) {
-                log.info("SSL Bundle 'client-auth' not available: {}", e.getMessage());
+                log.info("SSL Bundle '{}' not available: {}", e.getBundleName(), e.getMessage());
             }
         } else {
-            log.info("SSL Bundles not available: null");
+            log.info("SSL Bundles not available: sslBundles == null");
         }
-        return sslBundle;
-    }
-
-    @Bean
-    DrcClient drcClient(WebClient drcApiWebClient) {
-        HttpServiceProxyFactory httpServiceProxyFactory =
-                HttpServiceProxyFactory.builderFor(WebClientAdapter.create(drcApiWebClient)).build();
-        return httpServiceProxyFactory.createClient(DrcClient.class);
+        return Optional.empty();
     }
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/JacksonConfiguration.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/JacksonConfiguration.java
@@ -1,0 +1,97 @@
+package uk.gov.justice.laa.crime.dces.integration.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
+import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Configuration
+public class JacksonConfiguration {
+    /**
+     * Note that changes made in this method affect the ObjectMapper provided by Spring Boot, so are NOT limited to just
+     * the DrcApiWebClient and DrcClient or MaatApiWebClient and MaatApiClient, but also affect all JSON serialization
+     * and deserialization in the application.
+     * <p>
+     * This customizer makes two changes to the global Jackson ObjectMapper provided by Spring Boot:
+     * <ol>
+     *   <li>
+     *     The Advantis DRC API doesn't like `null` very much, so we use Mixins to ensure that the `CONTRIBUTIONS` and
+     *     `Fdc` classes (and their static nested classes) are serialized without nulls. If I were braver, I'd have used
+     *     `builder.serializationInclusion(JsonInclude.Include.NON_NULL)` which would affect every object serialized.
+     *   </li>
+     *   <li>
+     *     Default serialization of XMLGregorianCalendar calls #toCalendar() to convert it to a Calendar instance, then
+     *     serializes that as a number or a full ISO8601 timestamp string (depending on  WRITE_DATES_AS_TIMESTAMPS).
+     *     By overriding to use ToStringSerializer, #toString() calls #toXMLFormat(), which takes into account undefined
+     *     fields, so does not include the 'T00:00:00Z' time part for dates, for example.
+     *   </li>
+     * </ol>
+     *  @return A customizer for the Jackson ObjectMapper provided by Spring Boot.
+     */
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+        return builder -> builder
+                .serializationInclusion()
+                .mixIns(Arrays.stream(NON_NULL_CLASSES)
+                        .collect(Collectors.toMap(Function.identity(), clazz -> NonNullMixIn.class)))
+                .serializerByType(XMLGregorianCalendar.class, ToStringSerializer.instance);
+    }
+
+    /**
+     * Common MixIn class to apply to all the FDC and Concor Contribution DTO classes.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    static class NonNullMixIn {
+    }
+
+    /**
+     * Array of classes to apply the NonNullMixIn MixIn to. See `jsonCustomizer()` method.
+     */
+    private static final Class<?>[] NON_NULL_CLASSES = {
+            CONTRIBUTIONS.class,
+            CONTRIBUTIONS.Applicant.class,
+            CONTRIBUTIONS.Applicant.BankDetails.class,
+            CONTRIBUTIONS.Applicant.DisabilitySummary.class,
+            CONTRIBUTIONS.Applicant.EmploymentStatus.class,
+            CONTRIBUTIONS.Applicant.HomeAddress.class,
+            CONTRIBUTIONS.Applicant.Partner.class,
+            CONTRIBUTIONS.Applicant.PartnerDetails.class,
+            CONTRIBUTIONS.Applicant.PostalAddress.class,
+            CONTRIBUTIONS.Applicant.PreferredPaymentMethod.class,
+            CONTRIBUTIONS.Application.class,
+            CONTRIBUTIONS.Application.AppealType.class,
+            CONTRIBUTIONS.Application.CaseType.class,
+            CONTRIBUTIONS.Application.CcHardship.class,
+            CONTRIBUTIONS.Application.MagsCourt.class,
+            CONTRIBUTIONS.Application.OffenceType.class,
+            CONTRIBUTIONS.Application.RepStatus.class,
+            CONTRIBUTIONS.Application.Solicitor.class,
+            CONTRIBUTIONS.Assessment.class,
+            CONTRIBUTIONS.Assessment.AssessmentReason.class,
+            CONTRIBUTIONS.Assessment.IncomeEvidenceList.class,
+            CONTRIBUTIONS.BreathingSpaceInfo.class,
+            CONTRIBUTIONS.BreathingSpaceInfo.BreathingSpace.class,
+            CONTRIBUTIONS.CapitalSummary.class,
+            CONTRIBUTIONS.CapitalSummary.AssetList.class,
+            CONTRIBUTIONS.CapitalSummary.MotorVehicleOwnership.class,
+            CONTRIBUTIONS.CapitalSummary.PropertyList.class,
+            CONTRIBUTIONS.CcOutcomes.class,
+            CONTRIBUTIONS.CcOutcomes.CcOutcome.class,
+            CONTRIBUTIONS.Correspondence.class,
+            CONTRIBUTIONS.Correspondence.Letter.class,
+            CONTRIBUTIONS.Equity.class,
+            CONTRIBUTIONS.Equity.PropertyDescriptor.class,
+            CONTRIBUTIONS.Passported.class,
+            CONTRIBUTIONS.Passported.Reason.class,
+            CONTRIBUTIONS.Passported.Result.class,
+            FdcFile.FdcList.Fdc.class,
+    };
+}


### PR DESCRIPTION
## What

Separate out Jackson config, NON_NULL contribution records
- Separate out Jackson config into a separate `@Configuration` class
- Use `@JsonInclude(JsonInclude.Include.NON_NULL)` to serialize contribution records

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
