### PR TITLE
DCES-525 Add feature flag to prevent sending to DRC and updating status.

### DIFF
--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/Feature.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/Feature.java
@@ -1,0 +1,53 @@
+package uk.gov.justice.laa.crime.dces.integration.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Feature flags should be defined with a canonical name that is in lowercase kebab-case, like `my-good-name`.
+ * Following this convention and not deviating from it should lead to consistent naming of the bean properties and
+ * operating system environment variables.
+ * <p>
+ * The feature flag will be exposed as a method on the `Feature` record as a method in camelCase, like `myGoodName`.
+ * So a component can inject the `Feature` and use `if (feature.myGoodName()) {...}` to test for the feature.
+ * <p>
+ * Additionally, the annotation `@ConditionalOnProperty(prefix = "feature", name = "my-good-name")` (note the use
+ * of the lowercase kebab-case name) can be used on a component class or configuration bean method to instantiate that
+ * Spring context bean only if the feature is enabled.
+ * <p>
+ * Inside Kubernetes, users enable and disable features by editing the `feature` secret in the appropriate namespace.
+ * You can do this in AWS Console Secrets Manager, find the secret by its description, and then edit the key-values
+ * inside the secret in AWS. Each key name will be an environment variable, so they should be uppercase without dashes.
+ * 'my-good-name` will map to `FEATURE_MYGOODNAME` in the secrets and in the environment. Use `true` or `false` as the
+ * values. You may need to delete the Kubernetes secret and pod to get them to refresh/restart with the new values.
+ * <p>
+ * Outside of Kubernetes (for example, on your local development machine), you can normally just define an environment
+ * variable using the uppercase without dashes name in the Run/Debug configuration, like `FEATURE_MYGOODNAME=true`.
+ * <p>
+ * Note: Spring Boot's rules for environment variables are strict to make valid names on Windows, macOS and Linux (see
+ * <a href="https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties.relaxed-binding.environment-variables">here</a>
+ * for more details). The rules for properties in this class are more relaxed, but stick to camelCase for clarity.
+ * <p>
+ * Keep it simple with feature naming, just a few dash-separated words after `feature.` - otherwise you may hit one of
+ * <a href="https://github.com/spring-projects/spring-boot/issues?q=is%3Aissue+ConfigurationProperties+environment+variables+dashes">these issues</a>.
+ * If you plan to use `@Value` binding, then keeping it to a single word after `feature.` is advisable.
+ *
+ * @param stubAckEndpoints   initialize the `feature.stub-ack-endpoints` (`FEATURE_STUBACKENDPOINTS`) feature flag.
+ *                           This enables the StubAckFromDrcController class and its endpoints.
+ * @param tempTestEndpoints  initialize the `feature.temp-test-endpoints` (`FEATURE_TEMPTESTENDPOINTS`) feature flag.
+ *                           This enables the TempTestController class and its endpoints.
+ * @param incomingIsolated   initialize the `feature.incoming-isolated` (`FEATURE_INCOMINGISOLATED`) feature flag.
+ *                           This prevents incoming acknowledgements from modifying MAAT DB.
+ * @param outgoingIsolated   initialize the `feature.outgoing-isolated` (`FEATURE_OUTGOINGISOLATED`) feature flag.
+ *                           This prevents daily processing from modifying MAAT DB or from sending records to the DRC.
+ * @param outgoingAnonymized initialize the `feature.outgoing-anonymized` (`FEATURE_OUTGOINGANONYMIZED`) feature flag.
+ *                           This causes daily processing data to be anonymized before being sent to the DRC.
+ */
+@ConfigurationProperties(prefix = "feature")
+@Slf4j
+public record Feature(boolean stubAckEndpoints   /* feature.stub-ack-endpoints */,
+                      boolean tempTestEndpoints  /* feature.temp-test-endpoints */,
+                      boolean incomingIsolated   /* feature.incoming-isolated */,
+                      boolean outgoingIsolated   /* feature.outgoing-isolated */,
+                      boolean outgoingAnonymized /* feature.outgoing-anonymized */) {
+}

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/JacksonConfiguration.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/JacksonConfiguration.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import uk.gov.justice.laa.crime.dces.integration.model.ConcorContributionReqForDrc;
+import uk.gov.justice.laa.crime.dces.integration.model.FdcReqForDrc;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile;
 
@@ -55,6 +57,8 @@ public class JacksonConfiguration {
      * Array of classes to apply the NonNullMixIn MixIn to. See `jsonCustomizer()` method.
      */
     private static final Class<?>[] NON_NULL_CLASSES = {
+            ConcorContributionReqForDrc.class,
+            ConcorContributionReqForDrc.ConcorContributionReqData.class,
             CONTRIBUTIONS.class,
             CONTRIBUTIONS.Applicant.class,
             CONTRIBUTIONS.Applicant.BankDetails.class,
@@ -91,6 +95,8 @@ public class JacksonConfiguration {
             CONTRIBUTIONS.Passported.class,
             CONTRIBUTIONS.Passported.Reason.class,
             CONTRIBUTIONS.Passported.Result.class,
+            FdcReqForDrc.class,
+            FdcReqForDrc.FdcReqData.class,
             FdcFile.FdcList.Fdc.class,
     };
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/controller/StubAckFromDrcController.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/controller/StubAckFromDrcController.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.crime.dces.integration.controller;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,10 +19,11 @@ import java.util.Random;
  * This is a stub to simulate the endpoint that the DRC would call to asynchronously acknowledge their receipt of an
  * FDC or Concor Contribution record (see class AckFromDrcController for the real thing).
  */
-@Slf4j
-@RestController
-@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "feature", name = "stub-ack-endpoints")
 @RequestMapping("/api/dces/v1-stub")
+@RequiredArgsConstructor
+@RestController
+@Slf4j
 @SuppressWarnings("squid:S2245") // Safe to use random here, as it's not being used in any fashion beyond a return value.
 public class StubAckFromDrcController {
     private static final Random random = new Random();

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/controller/TempTestController.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/controller/TempTestController.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -33,12 +34,13 @@ import java.math.BigInteger;
 
 /**
  * This is a simple temporary controller to handle some test endpoints.
- * TODO: Remove or disable this controller once we're happy with everything.
+ * This feature should not be enabled in production.
  */
-@Slf4j
-@RestController
-@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "feature", name = "temp-test-endpoints")
 @RequestMapping(TempTestController.PREFIX)
+@RequiredArgsConstructor
+@RestController
+@Slf4j
 public class TempTestController {
     static final String PREFIX = "/api/dces/test";
     private final StubValidation stubValidation;
@@ -48,7 +50,7 @@ public class TempTestController {
     /**
      * Check we have connectivity with almost no side effects (just a log line).
      */
-    @GetMapping(value = "/")
+    @GetMapping(value = "")
     public String getTest() {
         log.info("Received GET {}", PREFIX);
         return "GET Test Successful";

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ConcorContributionReqForDrc.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ConcorContributionReqForDrc.java
@@ -1,24 +1,14 @@
 package uk.gov.justice.laa.crime.dces.integration.model;
 
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
-import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile;
 
 import java.util.Map;
-import java.util.Objects;
 
 public record ConcorContributionReqForDrc(ConcorContributionReqData data, Map<String, String> meta) {
     /**
      * @param concorContributionObj This field cannot be named `concorContribution` because of Entity Framework used by Advantis.
      */
     public record ConcorContributionReqData(int concorContributionId, CONTRIBUTIONS concorContributionObj) {
-        public ConcorContributionReqData(int concorContributionId, CONTRIBUTIONS concorContributionObj) {
-            this.concorContributionId = concorContributionId;
-            this.concorContributionObj = Objects.requireNonNull(concorContributionObj, "`concorContributionObj` must not be null");
-        }
-    }
-    public ConcorContributionReqForDrc(ConcorContributionReqData data, Map<String, String> meta) {
-        this.data = Objects.requireNonNull(data, "`data` must not be null");
-        this.meta = Objects.requireNonNull(meta, "`meta` must not be null");
     }
 
     public static ConcorContributionReqForDrc of(final int concorContributionId, final CONTRIBUTIONS concorContributionObj) {

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/FdcReqForDrc.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/FdcReqForDrc.java
@@ -3,21 +3,12 @@ package uk.gov.justice.laa.crime.dces.integration.model;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile;
 
 import java.util.Map;
-import java.util.Objects;
 
 public record FdcReqForDrc(FdcReqData data, Map<String, String> meta) {
     /**
      * @param fdcObj This field cannot be named just `fdc` because of Entity Framework used by Advantis.
      */
     public record FdcReqData(int fdcId, FdcFile.FdcList.Fdc fdcObj) {
-        public FdcReqData(int fdcId, FdcFile.FdcList.Fdc fdcObj) {
-            this.fdcId = fdcId;
-            this.fdcObj = Objects.requireNonNull(fdcObj, "`fdcObj` must not be null");
-        }
-    }
-    public FdcReqForDrc(FdcReqData data, Map<String, String> meta) {
-        this.data = Objects.requireNonNull(data, "`data` must not be null");
-        this.meta = Objects.requireNonNull(meta, "`meta` must not be null");
     }
 
     public static FdcReqForDrc of(final int fdcId, final FdcFile.FdcList.Fdc fdcObj) {

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
@@ -2,13 +2,14 @@ package uk.gov.justice.laa.crime.dces.integration.service;
 
 import io.github.resilience4j.retry.annotation.Retry;
 import io.micrometer.core.annotation.Timed;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
 import uk.gov.justice.laa.crime.dces.integration.client.FdcClient;
+import uk.gov.justice.laa.crime.dces.integration.config.Feature;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.exception.MaatApiClientException;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.model.fdc.FdcContributionEntry;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.model.fdc.FdcContributionsResponse;
@@ -27,8 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+@RequiredArgsConstructor
 @Service
-@AllArgsConstructor
 @Slf4j
 public class FdcService implements FileService {
     private static final String SERVICE_NAME = "FdcService";
@@ -36,10 +37,15 @@ public class FdcService implements FileService {
     private final FdcMapperUtils fdcMapperUtils;
     private final FdcClient fdcClient;
     private final DrcClient drcClient;
+    private final Feature feature;
 
     public Integer processFdcUpdate(UpdateLogFdcRequest updateLogFdcRequest) {
         try {
-            return fdcClient.sendLogFdcProcessed(updateLogFdcRequest);
+            if (!feature.incomingIsolated()) {
+                return fdcClient.sendLogFdcProcessed(updateLogFdcRequest);
+            } else {
+                return 0; // avoid updating MAAT DB.
+            }
         } catch (MaatApiClientException | WebClientResponseException | HttpServerErrorException e) {
             log.info("Failed to processFdcUpdate", e);
             throw e;
@@ -66,8 +72,12 @@ public class FdcService implements FileService {
         fdcList.forEach(currentFdc -> {
             int fdcId = currentFdc.getId().intValue();
             try {
-                drcClient.sendFdcReqToDrc(FdcReqForDrc.of(fdcId, currentFdc));
-                log.info("Sent FDC data to DRC, fdcId = {}", fdcId);
+                if (!feature.outgoingIsolated()) {
+                    drcClient.sendFdcReqToDrc(FdcReqForDrc.of(fdcId, currentFdc));
+                    log.info("Sent FDC data to DRC, fdcId = {}", fdcId);
+                } else {
+                    log.info("Skipping FDC data to DRC, fdcId = {}", fdcId);
+                }
                 successfulFdcs.add(currentFdc);
             } catch (Exception e) {
                 log.warn("Failed to send FDC data to DRC. fdcId = {}", fdcId, e);
@@ -143,6 +153,7 @@ public class FdcService implements FileService {
     @Retry(name = SERVICE_NAME)
     public FdcGlobalUpdateResponse callFdcGlobalUpdate(){
         try {
+            // Should this be prevented by `feature.outgoingIsolated()`?
             return fdcClient.executeFdcGlobalUpdate();
         } catch (HttpServerErrorException e) {
             // We're rethrowing the exception, therefore avoid logging the stack trace to prevent logging the same trace multiple times.
@@ -181,6 +192,10 @@ public class FdcService implements FileService {
                 .fdcIds(fdcIdList)
                 .xmlFileName(fileName)
                 .ackXmlContent(fileAckXML).build();
-        return fdcClient.updateFdcs(request);
+        if (!feature.outgoingIsolated()) {
+            return fdcClient.updateFdcs(request);
+        } else {
+            return 0;
+        }
     }
 }

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/FeatureAllFalseTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/FeatureAllFalseTest.java
@@ -1,0 +1,45 @@
+package uk.gov.justice.laa.crime.dces.integration.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.justice.laa.crime.dces.integration.controller.StubAckFromDrcController;
+import uk.gov.justice.laa.crime.dces.integration.controller.TempTestController;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@TestPropertySource(properties = """
+        feature.stub-ack-endpoints=false
+        feature.temp-test-endpoints=false
+        feature.incoming-isolated=false
+        feature.outgoing-isolated=false
+        feature.outgoing-anonymized=false
+        """)
+class FeatureAllFalseTest {
+    @Autowired
+    private Feature feature;
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    void givenFeatureAllFalse_whenCallFeatureMethods_thenMethodsReturnFalse() {
+        assertThat(feature.stubAckEndpoints()).isFalse();
+        assertThat(feature.tempTestEndpoints()).isFalse();
+        assertThat(feature.incomingIsolated()).isFalse();
+        assertThat(feature.outgoingIsolated()).isFalse();
+        assertThat(feature.outgoingAnonymized()).isFalse();
+    }
+
+    @Test
+    void givenFeatureAllFalse_whenLookForConditionalBeans_thenThrowsNoSuchBeanDefinition() {
+        assertThatThrownBy(() -> context.getBean(StubAckFromDrcController.class))
+                .isInstanceOf(NoSuchBeanDefinitionException.class);
+        assertThatThrownBy(() -> context.getBean(TempTestController.class))
+                .isInstanceOf(NoSuchBeanDefinitionException.class);
+    }
+}

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/FeatureAllTrueTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/FeatureAllTrueTest.java
@@ -1,0 +1,43 @@
+package uk.gov.justice.laa.crime.dces.integration.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.justice.laa.crime.dces.integration.controller.StubAckFromDrcController;
+import uk.gov.justice.laa.crime.dces.integration.controller.TempTestController;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@TestPropertySource(properties = """
+        feature.stub-ack-endpoints=true
+        feature.temp-test-endpoints=true
+        feature.incoming-isolated=true
+        feature.outgoing-isolated=true
+        feature.outgoing-anonymized=true
+        """)
+class FeatureAllTrueTest {
+    @Autowired
+    private Feature feature;
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    void givenFeatureAllTrue_whenCallFeatureMethods_thenMethodsReturnTrue() {
+        assertThat(feature.stubAckEndpoints()).isTrue();
+        assertThat(feature.tempTestEndpoints()).isTrue();
+        assertThat(feature.incomingIsolated()).isTrue();
+        assertThat(feature.outgoingIsolated()).isTrue();
+        assertThat(feature.outgoingAnonymized()).isTrue();
+    }
+
+    @Test
+    void givenFeatureAllTrue_whenLookForConditionalBeans_thenAnInstanceIsFound() {
+        assertThat(context.getBean(StubAckFromDrcController.class))
+                .isInstanceOf(StubAckFromDrcController.class);
+        assertThat(context.getBean(TempTestController.class))
+                .isInstanceOf(TempTestController.class);
+    }
+}

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/JacksonConfigurationTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/JacksonConfigurationTest.java
@@ -1,0 +1,45 @@
+package uk.gov.justice.laa.crime.dces.integration.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import uk.gov.justice.laa.crime.dces.integration.model.ConcorContributionReqForDrc;
+import uk.gov.justice.laa.crime.dces.integration.model.FdcReqForDrc;
+import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
+import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile;
+
+import javax.xml.datatype.DatatypeFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class JacksonConfigurationTest {
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void givenAConcorContributionReqForDrc_whenItIsSerialized_thenItHasNoNulls() throws JsonProcessingException {
+        var request = ConcorContributionReqForDrc.of(123, new CONTRIBUTIONS(), null);
+        String json = objectMapper.writeValueAsString(request);
+        assertThat(json).doesNotContain("null");
+    }
+
+    @Test
+    void givenAnFdcReqForDrc_whenItIsSerialized_thenItHasNoNulls() throws JsonProcessingException {
+        var request = FdcReqForDrc.of(123, new FdcFile.FdcList.Fdc(), null);
+        String json = objectMapper.writeValueAsString(request);
+        assertThat(json).doesNotContain("null");
+    }
+
+    @Test
+    void givenAnXMLGregorianCalendar_whenItIsSerialized_thenItHasIsoFormat() throws JsonProcessingException {
+        var dateOnly = DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar("2024-05-21");
+        var timeOnly = DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar("14:49:35");
+        var dateTime = DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar("2024-05-21T14:49:35");
+        assertThat(objectMapper.writeValueAsString(dateOnly)).isEqualTo("\"2024-05-21\"");
+        assertThat(objectMapper.writeValueAsString(timeOnly)).isEqualTo("\"14:49:35\"");
+        assertThat(objectMapper.writeValueAsString(dateTime)).isEqualTo("\"2024-05-21T14:49:35\"");
+    }
+}

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
+import uk.gov.justice.laa.crime.dces.integration.config.Feature;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.exception.MaatApiClientException;
 import uk.gov.justice.laa.crime.dces.integration.model.external.UpdateLogContributionRequest;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
@@ -39,28 +40,30 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
 @ExtendWith(SoftAssertionsExtension.class)
+@SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @WireMockTest(httpPort = 1111)
 class ContributionServiceTest {
+	private static final String GET_URL = "/debt-collection-enforcement/concor-contribution-files?status=ACTIVE";
+	private static final String UPDATE_URL = "/debt-collection-enforcement/create-contribution-file";
+
+	private static final List<StubMapping> customStubs = new ArrayList<>();
 
 	@InjectSoftAssertions
 	private SoftAssertions softly;
 
 	@MockBean
-	ContributionsMapperUtils contributionsMapperUtilsMock;
+	private ContributionsMapperUtils contributionsMapperUtils;
 
 	@MockBean
 	private DrcClient drcClient;
 
+	@MockBean
+	private Feature feature;
+
 	@Autowired
 	private ContributionService contributionService;
-
-	private static final List<StubMapping> customStubs = new ArrayList<>();
-
-	private static final String GET_URL = "/debt-collection-enforcement/concor-contribution-files?status=ACTIVE";
-	private static final String UPDATE_URL = "/debt-collection-enforcement/create-contribution-file";
 
 	@AfterEach
 	void afterTestAssertAll(){
@@ -70,45 +73,63 @@ class ContributionServiceTest {
 			WireMock.resetAllRequests();
 		}
 	}
+
 	@Test
 	void testXMLValid() throws JAXBException {
-
-		when(contributionsMapperUtilsMock.mapLineXMLToObject(any())).thenReturn(createTestContribution());
-		when(contributionsMapperUtilsMock.generateFileXML(any(), any())).thenReturn("ValidXML");
-		when(contributionsMapperUtilsMock.generateFileName(any())).thenReturn("TestFilename.xml");
-		when(contributionsMapperUtilsMock.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
+		when(contributionsMapperUtils.mapLineXMLToObject(any())).thenReturn(createTestContribution());
+		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("ValidXML");
+		when(contributionsMapperUtils.generateFileName(any())).thenReturn("TestFilename.xml");
+		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
 		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
 
 		boolean result = contributionService.processDailyFiles();
-		verify(contributionsMapperUtilsMock,times(2)).mapLineXMLToObject(any());
-		verify(contributionsMapperUtilsMock).generateFileXML(any(), any());
+
+		verify(contributionsMapperUtils, times(2)).mapLineXMLToObject(any());
+		verify(contributionsMapperUtils).generateFileXML(any(), any());
+		verify(drcClient, times(2)).sendConcorContributionReqToDrc(any());
+		softly.assertThat(result).isTrue();
+	}
+
+	@Test
+	void testXMLValidWhenOutgoingIsolated() throws JAXBException {
+		when(feature.outgoingIsolated()).thenReturn(true);
+		when(contributionsMapperUtils.mapLineXMLToObject(any())).thenReturn(createTestContribution());
+		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("ValidXML");
+		when(contributionsMapperUtils.generateFileName(any())).thenReturn("TestFilename.xml");
+		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
+		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
+
+		boolean result = contributionService.processDailyFiles();
+		verify(contributionsMapperUtils, times(2)).mapLineXMLToObject(any());
+		verify(contributionsMapperUtils).generateFileXML(any(), any());
+		verify(drcClient, times(0)).sendConcorContributionReqToDrc(any()); // not called when feature.outgoing-isolated=true.
 		softly.assertThat(result).isTrue();
 	}
 
 	@Test
 	void testFileXMLInvalid() throws JAXBException {
-		when(contributionsMapperUtilsMock.mapLineXMLToObject(any())).thenReturn(new CONTRIBUTIONS()); // mock returns null otherwise
-		when(contributionsMapperUtilsMock.generateFileXML(any(), any())).thenReturn("InvalidXML");
-		when(contributionsMapperUtilsMock.generateAckXML(any(),any(),any(),any())).thenReturn("AckXML");
-		when(contributionsMapperUtilsMock.generateFileName(any())).thenReturn("FileName");
+		when(contributionsMapperUtils.mapLineXMLToObject(any())).thenReturn(new CONTRIBUTIONS()); // mock returns null otherwise
+		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("InvalidXML");
+		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("AckXML");
+		when(contributionsMapperUtils.generateFileName(any())).thenReturn("FileName");
 		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
 
 		softly.assertThatThrownBy(() -> contributionService.processDailyFiles())
 				.isInstanceOf(HttpServerErrorException.class)
 				.hasMessageContaining("INTERNAL_SERVER_ERROR");
-		verify(contributionsMapperUtilsMock,times(2)).mapLineXMLToObject(any());
+		verify(contributionsMapperUtils, times(2)).mapLineXMLToObject(any());
 		// failure to generate the xml should return a null xmlString.
-		verify(contributionsMapperUtilsMock).generateFileXML(any(), any());
+		verify(contributionsMapperUtils).generateFileXML(any(), any());
 		// failure should be the result of file generation
 	}
 
 	@Test
 	void testLineXMLInvalid() throws JAXBException {
-		when(contributionsMapperUtilsMock.mapLineXMLToObject(any())).thenThrow(JAXBException.class);
+		when(contributionsMapperUtils.mapLineXMLToObject(any())).thenThrow(JAXBException.class);
 		contributionService.processDailyFiles();
-		verify(contributionsMapperUtilsMock,times(2)).mapLineXMLToObject(any());
+		verify(contributionsMapperUtils, times(2)).mapLineXMLToObject(any());
 		// with no successful xml, should not run the file generation.
-		verify(contributionsMapperUtilsMock, times(0)).generateFileXML(any(), any());
+		verify(contributionsMapperUtils, times(0)).generateFileXML(any(), any());
 	}
 
 	@Test
@@ -117,10 +138,10 @@ class ContributionServiceTest {
 		customStubs.add(stubFor(post(UPDATE_URL).atPriority(1)
 				.willReturn(serverError())));
 
-		when(contributionsMapperUtilsMock.mapLineXMLToObject(any())).thenReturn(createTestContribution());
-		when(contributionsMapperUtilsMock.generateFileXML(any(), any())).thenReturn("ValidXML");
-		when(contributionsMapperUtilsMock.generateFileName(any())).thenReturn("TestFilename.xml");
-		when(contributionsMapperUtilsMock.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
+		when(contributionsMapperUtils.mapLineXMLToObject(any())).thenReturn(createTestContribution());
+		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("ValidXML");
+		when(contributionsMapperUtils.generateFileName(any())).thenReturn("TestFilename.xml");
+		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
 		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
 		// do
 		softly.assertThatThrownBy(() -> contributionService.processDailyFiles())
@@ -138,6 +159,17 @@ class ContributionServiceTest {
 		Integer response = contributionService.processContributionUpdate(dataRequest);
 		softly.assertThat(response).isEqualTo(1111);
 	}
+
+	@Test
+	void testProcessContributionUpdateWhenIncomingIsolated() {
+		when(feature.incomingIsolated()).thenReturn(true);
+		UpdateLogContributionRequest dataRequest = UpdateLogContributionRequest.builder()
+				.concorId(911)
+				.build();
+		Integer response = contributionService.processContributionUpdate(dataRequest);
+		softly.assertThat(response).isEqualTo(0); // so MAAT DB not touched
+	}
+
 
 	@Test
 	void testProcessContributionUpdateWhenFailed() {

--- a/helm_deploy/laa-dces-drc-integration/templates/deployment.yaml
+++ b/helm_deploy/laa-dces-drc-integration/templates/deployment.yaml
@@ -27,11 +27,12 @@ spec:
       serviceAccountName: {{ include "laa-dces-drc-integration.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.clientAuth.volumeName }}
+      {{- if .Values.clientAuth }}
       volumes:
         - name: {{ .Values.clientAuth.volumeName }}
           secret:
             secretName: {{ .Values.clientAuth.secretName }}
+            optional: true
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
@@ -48,10 +49,10 @@ spec:
               containerPort: {{ .Values.actuator.port }}
               protocol: TCP
             {{- end }}
-          {{- if .Values.clientAuth.volumeName }}
+          {{- if .Values.clientAuth }}
           volumeMounts:
-            - mountPath: {{ .Values.clientAuth.mountPath }}
-              name: {{ .Values.clientAuth.volumeName }}
+            - name: {{ .Values.clientAuth.volumeName }}
+              mountPath: {{ .Values.clientAuth.mountPath }}
               readOnly: true
           {{- end }}
           livenessProbe:
@@ -78,6 +79,10 @@ spec:
             periodSeconds: {{ .Values.actuator.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.actuator.readiness.timeoutSeconds }}
             failureThreshold: {{ .Values.actuator.readiness.failureThreshold }}
+          envFrom:
+            - secretRef:
+                name: feature
+                optional: true
           {{ include "laa-dces-drc-integration.env-vars" . | nindent 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
## What

[DCES-525](https://dsdmoj.atlassian.net/browse/DCES-525) Add feature flag to prevent sending to DRC and updating status.
- Add feature flag implementation based on `FEATURE_[A-Z]*` environment variables imported as the secret keys from a K8s external secret and a `ConfigurationProperties` context bean.
- Change the K8s deployment YAML to expose this optional secret into the pod/container environment (in addition to existing variables).
- Add the DTO classes to the Jackson configuration for NON_NULL JSON serialization and simplified the DTO classes' constructor null checks.
- Make the StubAckFromDrcController and TempTestController controller classes be conditional on feature flags (endpoints can be disabled).
- Change the processDailyFiles methods to prevent "outgoing" data sent to the DRC and updates to the status of contribution records based on a feature flag.
- Change the "incoming" endpoints for the DRC to acknowledge records to prevent updating the MAAT DB based on a feature flag.
- Add unit tests for JacksonConfiguration and Feature classes.
- Add unit tests for incomingIsolated and outgoingIsolated features in tests for ContributionService and FdcService.

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.


[DCES-525]: https://dsdmoj.atlassian.net/browse/DCES-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ