### PR TITLE
Make feature flag also disable global FDC update

### DIFF
--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
@@ -158,8 +158,11 @@ public class FdcService implements FileService {
     @Retry(name = SERVICE_NAME)
     public FdcGlobalUpdateResponse callFdcGlobalUpdate(){
         try {
-            // Should this be prevented by `feature.outgoingIsolated()`?
-            return fdcClient.executeFdcGlobalUpdate();
+            if (!feature.outgoingIsolated()) {
+                return fdcClient.executeFdcGlobalUpdate();
+            } else {
+                return new FdcGlobalUpdateResponse(true, 0);
+            }
         } catch (HttpServerErrorException e) {
             // We're rethrowing the exception, therefore avoid logging the stack trace to prevent logging the same trace multiple times.
             log.error("FDC global update threw an exception [" + e.getClass().getName() + "(" + e.getMessage() + ")]");

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/FdcServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/FdcServiceTest.java
@@ -112,11 +112,11 @@ class FdcServiceTest {
 		verify(fdcMapperUtils).generateFileName(any());
 		verify(fdcMapperUtils).generateAckXML(any(), any(), any(), any());
 		verify(fdcMapperUtils, times(12)).mapFdcEntry(any());
-		verify(drcClient, times(0)).sendConcorContributionReqToDrc(any());
+		verify(drcClient, times(0)).sendConcorContributionReqToDrc(any()); // nothing sent to DRC
 		softly.assertThat(successful).isTrue();
 		WireMock.verify(1, getRequestedFor(urlEqualTo(GET_URL)));
-		WireMock.verify(1, postRequestedFor(urlEqualTo(PREPARE_URL)));
-		WireMock.verify(0, postRequestedFor(urlEqualTo(UPDATE_URL)));
+		WireMock.verify(0, postRequestedFor(urlEqualTo(PREPARE_URL))); // no FDC global update
+		WireMock.verify(0, postRequestedFor(urlEqualTo(UPDATE_URL))); // no changes to statuses or contribution_files
 	}
 
 	@Test


### PR DESCRIPTION
## What

Make feature flag also disable global FDC update
- Following on from [DCES-525](https://dsdmoj.atlassian.net/browse/DCES-525), discussed with Tariq and agreed that the `feature.outgoing-isolated` feature flag should also disable the global FDC update.

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.


[DCES-525]: https://dsdmoj.atlassian.net/browse/DCES-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ