### PR TITLE
DCES-550 fix Circle CI deployment 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ commands:
           no_output_timeout: 20m
           command: |
             kubectl wait --for=condition=ready pod/${POD_NAME} --timeout=60s -n ${NAMESPACE}
-            kubectl exec -n ${NAMESPACE} ${POD_NAME} -- ./gradlew clean compileIntegrationTestJava processIntegrationTestResources
+            kubectl exec -n ${NAMESPACE} ${POD_NAME} -- ./gradlew --no-daemon clean compileIntegrationTestJava processIntegrationTestResources
             kubectl exec -n ${NAMESPACE} ${POD_NAME} -- ./gradlew integrationTest -Dorg.gradle.jvmargs=-Xmx2g
       - run:
           name: Fetch Integration Test results


### PR DESCRIPTION


## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-550)

The CI pipeline was failing during the integration test stage with this error:

```
Task :integrationTest
command terminated with exit code 137

```

This seems to be caused by an out-of-memory error caused by the usage of the Gradle Daemon. By default the gradle daemon process continues to run in the background between builds and this holds on to some memory, meaning that the build itself has less memory to work with. The daemon makes builds faster on developer machines, but can cause memory issues in CI pipelines which are run on VMs with less memory.

Hence it is recommended to disable the daemon on CI pipelines (https://docs.gradle.org/3.3/userguide/gradle_daemon.html#when_should_i_not_use_the_gradle_daemon).

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
