### PR TITLE
DCES-534 Change incoming APIs to use ProblemDetail report

### DIFF
--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ConcorContributionAckFromDrc.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ConcorContributionAckFromDrc.java
@@ -1,12 +1,18 @@
 package uk.gov.justice.laa.crime.dces.integration.model;
 
+import org.springframework.http.ProblemDetail;
+
 import java.util.Map;
 
 public record ConcorContributionAckFromDrc(ConcorContributionAckData data, Map<String, String> meta) {
-    public record ConcorContributionAckData(int concorContributionId, Integer maatId, String errorText) {
+    public record ConcorContributionAckData(int concorContributionId, Integer maatId, ProblemDetail report) {
+        public String errorText() {
+            return ProblemDetails.toErrorText(report);
+        }
     }
 
-    public static ConcorContributionAckFromDrc of(int concorContributionId, String errorText) {
-        return new ConcorContributionAckFromDrc(new ConcorContributionAckData(concorContributionId, null, errorText), Map.of());
+    public static ConcorContributionAckFromDrc of(final int concorContributionId, final String errorText) {
+        return new ConcorContributionAckFromDrc(new ConcorContributionAckData(concorContributionId, null,
+                ProblemDetails.fromErrorText(errorText)), Map.of());
     }
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/FdcAckFromDrc.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/FdcAckFromDrc.java
@@ -1,12 +1,18 @@
 package uk.gov.justice.laa.crime.dces.integration.model;
 
+import org.springframework.http.ProblemDetail;
+
 import java.util.Map;
 
 public record FdcAckFromDrc(FdcAckData data, Map<String, String> meta) {
-    public record FdcAckData(int fdcId, Integer maatId, String errorText) {
+    public record FdcAckData(int fdcId, Integer maatId, ProblemDetail report) {
+        public String errorText() {
+            return ProblemDetails.toErrorText(report);
+        }
     }
 
-    public static FdcAckFromDrc of(int fdcId, String errorText) {
-        return new FdcAckFromDrc(new FdcAckData(fdcId, null, errorText), Map.of());
+    public static FdcAckFromDrc of(final int fdcId, final String errorText) {
+        return new FdcAckFromDrc(new FdcAckData(fdcId, null,
+                ProblemDetails.fromErrorText(errorText)), Map.of());
     }
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ProblemDetails.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ProblemDetails.java
@@ -1,0 +1,49 @@
+package uk.gov.justice.laa.crime.dces.integration.model;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+
+/**
+ * Utility class to convert between error text and ProblemDetail.
+ */
+final class ProblemDetails {
+    private static final String DEFAULT_ERROR_TEXT = "Internal Server Error";
+
+    private ProblemDetails() {
+        // Prevent instantiation.
+    }
+
+    /**
+     * Convert an error text to a ProblemDetail,
+     *
+     * @param errorText String error text.
+     * @return a ProblemDetail instance with the error text as the detail.
+     * If the error text is null, null is returned.
+     */
+    static ProblemDetail fromErrorText(final String errorText) {
+        return errorText != null ? ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, errorText) : null;
+    }
+
+    /**
+     * Convert a ProblemDetail to an error text.
+     *
+     * @param problemDetail ProblemDetail instance.
+     * @return an error text populated from the detail or title of the ProblemDetail.
+     * If neither are present, a fixed message is returned.
+     * If the ProblemDetail is null, null is returned.
+     */
+    static String toErrorText(final ProblemDetail problemDetail) {
+        if (problemDetail != null) {
+            String errorText = problemDetail.getDetail();
+            if (errorText == null) {
+                errorText = problemDetail.getTitle();
+                if (errorText == null) {
+                    errorText = DEFAULT_ERROR_TEXT; // fixed message if no detail or title
+                }
+            }
+            return errorText;
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## What

[DCES-534](https://dsdmoj.atlassian.net/browse/DCES-534) Change incoming APIs to use ProblemDetail report

Normally only the `detail` member (human-readable description of the issue) of the `ProblemDetail` is stored in the MAAT DB's `CONTRIBUTION_FILE_ERRORS.ERROR_TEXT` column. However, the other members could be stored in the DRC integration's own database, logged by the application to help troubleshooting, or used for making decisions on how to handle error reports.

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.


[DCES-534]: https://dsdmoj.atlassian.net/browse/DCES-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ