### PR TITLE
Fix for the non-blocking error caused by Hibernate.

### DIFF
--- a/dces-drc-integration/src/test/resources/application.yaml
+++ b/dces-drc-integration/src/test/resources/application.yaml
@@ -36,6 +36,10 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     show-sql: false
     generate-ddl: false
+    properties:
+      hibernate:
+        boot:
+          allow_jdbc_metadata_access: false
   # the following stops the ServiceSheduler from running in test profile
   profiles:
     active: test


### PR DESCRIPTION
Adding a config to stop hibernate throwing an exception due to trying to access the non-existent CI db.

https://docs.jboss.org/hibernate/orm/6.5/migration-guide/migration-guide.html#jdbc-metadata-on-boot

As the db is not actually accessed in CI/local in the unit tests. Have just stopped it trying. 