### PR TITLE
DCES-584 Add OAuth2 to the DRC client

### DIFF
--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/utils/RequestSpecificationBuilder.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/utils/RequestSpecificationBuilder.java
@@ -3,10 +3,9 @@ package uk.gov.justice.laa.crime.dces.integration.utils;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.stereotype.Component;
-import uk.gov.justice.laa.crime.dces.integration.config.ServicesConfiguration;
+import uk.gov.justice.laa.crime.dces.integration.config.ServicesProperties;
 import uk.gov.justice.laa.crime.dces.integration.utils.auth.OAuthTokenUtil;
 
 import static io.restassured.filter.log.LogDetail.ALL;
@@ -21,8 +20,8 @@ public class RequestSpecificationBuilder {
     private String MAAT_CD_AUTH_TOKEN_URI;
 
     @Autowired
-    private RequestSpecificationBuilder(@Qualifier("servicesConfiguration") ServicesConfiguration configuration, OAuth2ClientProperties oauthProperties) {
-        this.MAAT_CD_BASE_URL = configuration.getMaatApi().getBaseUrl();
+    private RequestSpecificationBuilder(ServicesProperties services, OAuth2ClientProperties oauthProperties) {
+        this.MAAT_CD_BASE_URL = services.getMaatApi().getBaseUrl();
         OAuth2ClientProperties.Provider maatProvider = oauthProperties.getProvider().get("maatapi");
         this.MAAT_CD_AUTH_TOKEN_URI = maatProvider.getTokenUri();
         OAuth2ClientProperties.Registration maatRegistration = oauthProperties.getRegistration().get("maatapi");

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/DrcClient.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/DrcClient.java
@@ -2,7 +2,6 @@ package uk.gov.justice.laa.crime.dces.integration.client;
 
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PostExchange;
 import uk.gov.justice.laa.crime.dces.integration.model.ConcorContributionReqForDrc;
@@ -10,9 +9,6 @@ import uk.gov.justice.laa.crime.dces.integration.model.FdcReqForDrc;
 
 @HttpExchange
 public interface DrcClient {
-    @GetExchange("/hello")
-    String hello();
-
     @PostExchange("/laa/v1/contribution")
     void sendConcorContributionReqToDrc(@NotNull @RequestBody ConcorContributionReqForDrc request);
 

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/FeatureProperties.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/FeatureProperties.java
@@ -43,9 +43,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *                           This causes daily processing data to be anonymized before being sent to the DRC.
  */
 @ConfigurationProperties(prefix = "feature")
-public record Feature(boolean stubAckEndpoints   /* feature.stub-ack-endpoints */,
-                      boolean tempTestEndpoints  /* feature.temp-test-endpoints */,
-                      boolean incomingIsolated   /* feature.incoming-isolated */,
-                      boolean outgoingIsolated   /* feature.outgoing-isolated */,
-                      boolean outgoingAnonymized /* feature.outgoing-anonymized */) {
+public record FeatureProperties(boolean stubAckEndpoints   /* feature.stub-ack-endpoints */,
+                                boolean tempTestEndpoints  /* feature.temp-test-endpoints */,
+                                boolean incomingIsolated   /* feature.incoming-isolated */,
+                                boolean outgoingIsolated   /* feature.outgoing-isolated */,
+                                boolean outgoingAnonymized /* feature.outgoing-anonymized */) {
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/ServicesProperties.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/config/ServicesProperties.java
@@ -1,31 +1,20 @@
 package uk.gov.justice.laa.crime.dces.integration.config;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Data
-@Configuration
 @ConfigurationProperties(prefix = "services")
-public class ServicesConfiguration {
-
-    private static final String REGISTERED_ID = "maatapi";
-
+@Data
+public class ServicesProperties {
     @NotNull
     private MaatApi maatApi;
 
     @NotNull
     private DrcClientApi drcClientApi;
 
-
     @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
     public static class MaatApi {
-
         @NotNull
         private String baseUrl;
 
@@ -40,12 +29,10 @@ public class ServicesConfiguration {
     }
 
     @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
     public static class DrcClientApi {
-
         @NotNull
         private String baseUrl;
+
         private boolean oAuthEnabled;
     }
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/controller/TempTestController.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/controller/TempTestController.java
@@ -57,15 +57,6 @@ public class TempTestController {
     }
 
     /**
-     * Forward to the '/hello' service at Advantis, that returns 'hello there!' as plain text.
-     */
-    @GetMapping(value = "/hello")
-    public String forwardHello() {
-        log.info("Received GET {}/hello", PREFIX);
-        return drcClient.hello();
-    }
-
-    /**
      * Forward a hard-coded fake FDC to the fdc endpoint at Advantis.
      */
     @GetMapping(value = "/fdc")

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
@@ -14,7 +14,7 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import uk.gov.justice.laa.crime.dces.integration.client.ContributionClient;
 import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
-import uk.gov.justice.laa.crime.dces.integration.config.Feature;
+import uk.gov.justice.laa.crime.dces.integration.config.FeatureProperties;
 import uk.gov.justice.laa.crime.dces.integration.datasource.EventService;
 import uk.gov.justice.laa.crime.dces.integration.enums.ContributionRecordStatus;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.exception.MaatApiClientException;
@@ -52,7 +52,7 @@ public class ContributionService implements FileService {
     private final ContributionClient contributionClient;
     private final DrcClient drcClient;
     private final ObjectMapper objectMapper;
-    private final Feature feature;
+    private final FeatureProperties feature;
     private final AnonymisingDataService anonymisingDataService;
     private final EventService eventService;
     private BigInteger batchId;

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
 import uk.gov.justice.laa.crime.dces.integration.client.FdcClient;
-import uk.gov.justice.laa.crime.dces.integration.config.Feature;
+import uk.gov.justice.laa.crime.dces.integration.config.FeatureProperties;
 import uk.gov.justice.laa.crime.dces.integration.datasource.EventService;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.exception.MaatApiClientException;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.model.fdc.FdcContributionEntry;
@@ -54,7 +54,7 @@ public class FdcService implements FileService {
     private final FdcClient fdcClient;
     private final DrcClient drcClient;
     private final ObjectMapper objectMapper;
-    private final Feature feature;
+    private final FeatureProperties feature;
     private final EventService eventService;
     private BigInteger batchId;
 

--- a/dces-drc-integration/src/main/resources/application.yaml
+++ b/dces-drc-integration/src/main/resources/application.yaml
@@ -71,6 +71,8 @@ spring:
         provider:
           maatapi:
             token-uri: ${MAAT_API_OAUTH_URL}
+          drc-client-api:
+            token-uri: ${DRC_API_OAUTH_URL}
         registration:
           maatapi:
             client-id: ${MAAT_API_OAUTH_CLIENT_ID}
@@ -78,6 +80,12 @@ spring:
             authorization-grant-type: client_credentials
             scope:
               - ${MAAT_API_OAUTH_SCOPE}
+          drc-client-api:
+            client-id: ${DRC_API_OAUTH_CLIENT_ID}
+            client-secret: ${DRC_API_OAUTH_CLIENT_SECRET}
+            authorization-grant-type: client_credentials
+            scope:
+              - ${DRC_API_OAUTH_SCOPE}
       resource-server:
         jwt:
           issuer-uri: ${LAA_DCES_DRC_INTEGRATION_RESOURCE_SERVER_ISSUER_URI}

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/DrcApiWebClientConfigurationTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/DrcApiWebClientConfigurationTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 class DrcApiWebClientConfigurationTest {
 
     @Mock
-    private ServicesConfiguration servicesConfiguration;
+    private ServicesProperties services;
 
     @Mock
     private WebClient.Builder webClientBuilder;
@@ -27,15 +27,15 @@ class DrcApiWebClientConfigurationTest {
     private WebClient webClient;
 
     @Mock
-    private ServicesConfiguration.DrcClientApi drcClientApi;
+    private ServicesProperties.DrcClientApi drcClientApi;
 
     @InjectMocks
     private DrcApiWebClientConfiguration drcApiWebClientConfiguration;
 
     @BeforeEach
     void setUp() {
-        when(servicesConfiguration.getDrcClientApi()).thenReturn(drcClientApi);
-        when(servicesConfiguration.getDrcClientApi().getBaseUrl()).thenReturn("http://localhost:8080");
+        when(services.getDrcClientApi()).thenReturn(drcClientApi);
+        when(services.getDrcClientApi().getBaseUrl()).thenReturn("http://localhost:8080");
         when(webClientBuilder.clone()).thenReturn(webClientBuilder);
         when(webClientBuilder.baseUrl(anyString())).thenReturn(webClientBuilder);
         when(webClientBuilder.filter(any())).thenReturn(webClientBuilder);
@@ -45,7 +45,7 @@ class DrcApiWebClientConfigurationTest {
 
     @Test
     void shouldReturnWebClientWhenDrcApiWebClientIsCalled() {
-        WebClient result = drcApiWebClientConfiguration.drcApiWebClient(webClientBuilder, servicesConfiguration);
+        WebClient result = drcApiWebClientConfiguration.drcApiWebClient(webClientBuilder, services);
         assertNotNull(result);
     }
 

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/FeaturePropertiesAllFalseTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/FeaturePropertiesAllFalseTest.java
@@ -20,9 +20,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         feature.outgoing-isolated=false
         feature.outgoing-anonymized=false
         """)
-class FeatureAllFalseTest {
+class FeaturePropertiesAllFalseTest {
     @Autowired
-    private Feature feature;
+    private FeatureProperties feature;
     @Autowired
     private ApplicationContext context;
 

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/FeaturePropertiesAllTrueTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/FeaturePropertiesAllTrueTest.java
@@ -18,9 +18,9 @@ import static org.assertj.core.api.Assertions.assertThat;
         feature.outgoing-isolated=true
         feature.outgoing-anonymized=true
         """)
-class FeatureAllTrueTest {
+class FeaturePropertiesAllTrueTest {
     @Autowired
-    private Feature feature;
+    private FeatureProperties feature;
     @Autowired
     private ApplicationContext context;
 

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/MaatApiWebClientConfigurationTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/MaatApiWebClientConfigurationTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -40,19 +39,18 @@ class MaatApiWebClientConfigurationTest {
     @Autowired
     private MeterRegistry meterRegistry;
 
-    @Qualifier("servicesConfiguration")
     @Autowired
-    private ServicesConfiguration configuration;
+    private ServicesProperties services;
+
     @MockBean
     OAuth2AuthorizedClientManager authorizedClientManager;
-
 
     @BeforeAll
     public void setup() throws IOException {
 
         mockWebServer = new MockWebServer();
         mockWebServer.start();
-        configuration.getMaatApi().setBaseUrl(String.format("http://localhost:%s", mockWebServer.getPort()));
+        services.getMaatApi().setBaseUrl(String.format("http://localhost:%s", mockWebServer.getPort()));
 
         maatApiWebClientFactory = new MaatApiWebClientConfiguration(meterRegistry);
     }
@@ -69,7 +67,7 @@ class MaatApiWebClientConfigurationTest {
         expectedResponse.setXmlContent("xmlContent");
         setupValidResponse(expectedResponse);
 
-        WebClient actualWebClient = maatApiWebClientFactory.maatApiWebClient(webClientBuilder, configuration, authorizedClientManager);
+        WebClient actualWebClient = maatApiWebClientFactory.maatApiWebClient(webClientBuilder, services, authorizedClientManager);
 
         assertThat(actualWebClient).isNotNull();
         assertThat(actualWebClient).isInstanceOf(WebClient.class);
@@ -91,7 +89,7 @@ class MaatApiWebClientConfigurationTest {
     private ConcorContribEntry mockWebClientRequest(WebClient webClient) {
         return webClient
                 .get()
-                .uri(configuration.getMaatApi().getBaseUrl())
+                .uri(services.getMaatApi().getBaseUrl())
                 .retrieve()
                 .bodyToMono(ConcorContribEntry.class)
                 .block();

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/ServicesPropertiesTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/ServicesPropertiesTest.java
@@ -2,30 +2,28 @@ package uk.gov.justice.laa.crime.dces.integration.config;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.Environment;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-@SpringBootTest
-@EnableConfigurationProperties(value = ServicesConfiguration.class)
-class ServicesConfigurationTest {
 
+@SpringBootTest
+@EnableConfigurationProperties(value = ServicesProperties.class)
+class ServicesPropertiesTest {
     @Autowired
-    @Qualifier("servicesConfiguration")
-    private ServicesConfiguration configuration;
+    private ServicesProperties services;
 
     @Autowired
     Environment env;
 
     @Test
     void givenDefinedBasedURL_whenGetBaseUrlIsInvoked_thenCorrectBaseURLIsReturned() {
-        assertThat(configuration.getMaatApi().getBaseUrl()).isEqualTo("http://localhost:1111");
+        assertThat(services.getMaatApi().getBaseUrl()).isEqualTo("http://localhost:1111");
     }
 
     @Test
     void givenDefinedBasedURL_whenGetBaseUrlIsInvoked_thenDrcApiBaseURLIsReturned() {
-        assertThat(configuration.getDrcClientApi().getBaseUrl()).isEqualTo("http://localhost:2222");
+        assertThat(services.getDrcClientApi().getBaseUrl()).isEqualTo("http://localhost:2222");
     }
 }

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
-import uk.gov.justice.laa.crime.dces.integration.config.Feature;
+import uk.gov.justice.laa.crime.dces.integration.config.FeatureProperties;
 import uk.gov.justice.laa.crime.dces.integration.datasource.EventService;
 import uk.gov.justice.laa.crime.dces.integration.datasource.model.EventType;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.exception.MaatApiClientException;
@@ -80,7 +80,7 @@ class ContributionServiceTest {
 	private DrcClient drcClient;
 
 	@MockBean
-	private Feature feature;
+	private FeatureProperties feature;
 
 	@Autowired
 	private ContributionService contributionService;

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/FdcServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/FdcServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import uk.gov.justice.laa.crime.dces.integration.client.DrcClient;
-import uk.gov.justice.laa.crime.dces.integration.config.Feature;
+import uk.gov.justice.laa.crime.dces.integration.config.FeatureProperties;
 import uk.gov.justice.laa.crime.dces.integration.datasource.EventService;
 import uk.gov.justice.laa.crime.dces.integration.datasource.model.EventType;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.exception.MaatApiClientException;
@@ -83,7 +83,7 @@ class FdcServiceTest {
 	private DrcClient drcClient;
 
 	@MockBean
-	private Feature feature;
+	private FeatureProperties feature;
 
 	@MockBean
 	private EventService eventService;


### PR DESCRIPTION
## What

[DCES-584](https://dsdmoj.atlassian.net/browse/DCES-584) Add OAuth2 to the DRC client
- Rename `@ConfigurationProperties` classes to `-Properties` for consistency.
- Add `@Qualifier` to usages of the two `WebClient` context beans to make their usage unambiguous (it likely worked before because of parameter names being default qualifiers)
- Add simple client_credentials OAuth2 configuration to the `drcApiWebClient` bean.

Currently the OAuth2 configuration on the DRC API is not enabled, and the configuration parameters (`DRC_API_OAUTH_*` environment variables) are all undefined. However, they could easily be set in `config-variables`.

## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.


[DCES-584]: https://dsdmoj.atlassian.net/browse/DCES-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ