### PR TITLE
DCES-608 - Refactor Ids/Numbers for consistency across the service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 dces-drc-integration/.gradle
 dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/generated/
 
+# dotenv environment variable files
+dces-drc-integration/.env
+dces-drc-integration/.env.*
+
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/dces-drc-integration/build.gradle
+++ b/dces-drc-integration/build.gradle
@@ -175,19 +175,25 @@ tasks.register('xsd2java') {
 		ant.xjc(
 				destdir: '${jaxbTargetDir}',
 				package: 'uk.gov.justice.laa.crime.dces.integration.model.generated.fdc',
-				schema: 'src/main/resources/schemas/fdc.xsd'
+				schema: 'src/main/resources/schemas/fdc.xsd',
+				extension: 'true',
+				binding: 'src/main/resources/schemas/bindings_general.xml'
 		)
 
 		ant.xjc(
 				destdir: '${jaxbTargetDir}',
 				package: 'uk.gov.justice.laa.crime.dces.integration.model.generated.contributions',
-				schema: 'src/main/resources/schemas/contributions.xsd'
+				schema: 'src/main/resources/schemas/contributions.xsd',
+				extension: 'true',
+				binding: 'src/main/resources/schemas/bindings_general.xml'
 		)
 
 		ant.xjc(
 				destdir: '${jaxbTargetDir}',
 				package: 'uk.gov.justice.laa.crime.dces.integration.model.generated.ack',
-				schema: 'src/main/resources/schemas/fileACK.xsd'
+				schema: 'src/main/resources/schemas/fileACK.xsd',
+				extension: 'true',
+				binding: 'src/main/resources/schemas/bindings_fileACK.xml'
 		)
 	}
 }

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/EventLogAssertService.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/service/EventLogAssertService.java
@@ -13,7 +13,6 @@ import uk.gov.justice.laa.crime.dces.integration.datasource.model.EventTypeEntit
 import uk.gov.justice.laa.crime.dces.integration.datasource.repository.CaseSubmissionRepository;
 import uk.gov.justice.laa.crime.dces.integration.datasource.repository.EventTypeRepository;
 
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -30,10 +29,10 @@ public class EventLogAssertService {
     private CaseSubmissionRepository caseSubmissionRepository;
     @Autowired
     private EventTypeRepository eventTypeRepository;
-    private BigInteger batchId;
+    private Long batchId;
     private SoftAssertions softly;
 
-    public void deleteAllByBatchId(BigInteger batchId){
+    public void deleteAllByBatchId(Long batchId){
         caseSubmissionRepository.deleteAllByBatchId(batchId);
     }
 

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/ContributionIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/ContributionIntegrationTest.java
@@ -30,7 +30,6 @@ import uk.gov.justice.laa.crime.dces.integration.service.EventLogAssertService;
 import uk.gov.justice.laa.crime.dces.integration.service.spy.ContributionProcessSpy;
 import uk.gov.justice.laa.crime.dces.integration.service.spy.SpyFactory;
 
-import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -66,22 +65,22 @@ class ContributionIntegrationTest {
     @Captor
     ArgumentCaptor<CaseSubmissionEntity> caseSubmissionEntityArgumentCaptor;
 
-    private static final BigInteger testBatchId = BigInteger.valueOf(-333L);
+    private static final Long TEST_BATCH_ID = -333L;
 
     @AfterEach
     void assertAll() {
-        eventLogAssertService.deleteAllByBatchId(testBatchId);
+        eventLogAssertService.deleteAllByBatchId(TEST_BATCH_ID);
         softly.assertAll();
     }
 
     @BeforeEach
     public void setBatchIdToTest(){
-        eventLogAssertService.deleteAllByBatchId(testBatchId);
-        when(eventService.generateBatchId()).thenReturn(testBatchId);
+        eventLogAssertService.deleteAllByBatchId(TEST_BATCH_ID);
+        when(eventService.generateBatchId()).thenReturn(TEST_BATCH_ID);
     }
     @BeforeAll
     public void setupHelper(){
-        eventLogAssertService.setBatchId(testBatchId);
+        eventLogAssertService.setBatchId(TEST_BATCH_ID);
         eventLogAssertService.setSoftly(softly);
     }
 
@@ -89,7 +88,7 @@ class ContributionIntegrationTest {
     void testProcessContributionUpdateWhenNotFound() {
         final String errorText = "The request has failed to process";
         final var contributionProcessedRequest = ContributionProcessedRequest.builder()
-                .concorId(9)
+                .concorId(9L)
                 .errorText(errorText)
                 .build();
         softly.assertThatThrownBy(() -> contributionService.handleContributionProcessedAck(contributionProcessedRequest))
@@ -101,7 +100,7 @@ class ContributionIntegrationTest {
     void testProcessContributionUpdateWhenFound() {
         final String errorText = "Error Text updated successfully.";
         final var contributionProcessedRequest = ContributionProcessedRequest.builder()
-                .concorId(47959912)
+                .concorId(47959912L)
                 .errorText(errorText)
                 .build();
         final Integer response = contributionService.handleContributionProcessedAck(contributionProcessedRequest);
@@ -112,7 +111,7 @@ class ContributionIntegrationTest {
     // Just verify we're submitting what is expected to the DB. Persistence testing itself is done elsewhere.
     private void assertProcessConcorCaseSubmissionCreation(ContributionProcessedRequest request, HttpStatusCode expectedStatusCode) {
         CaseSubmissionEntity expectedCaseSubmission = CaseSubmissionEntity.builder()
-                .concorContributionId(BigInteger.valueOf(request.getConcorId()))
+                .concorContributionId(request.getConcorId())
                 .payload(request.getErrorText())
                 .eventType(eventLogAssertService.getIdForEventType(EventType.DRC_ASYNC_RESPONSE))
                 .httpStatus(expectedStatusCode.value())

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/DbLoggingTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/DbLoggingTest.java
@@ -16,7 +16,6 @@ import uk.gov.justice.laa.crime.dces.integration.exception.DcesDrcServiceExcepti
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile.FdcList.Fdc;
 
-import java.math.BigInteger;
 import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,27 +33,27 @@ class DbLoggingTest {
   private CaseSubmissionRepository caseSubmissionRepository;
 
   private final String testPayloadString = "TestData"+ LocalDateTime.now();
-  private final BigInteger testBatchId = BigInteger.valueOf(-999);
-  private final BigInteger testTraceId = BigInteger.valueOf(-999);
+  private static final Long TEST_BATCH_ID = -999L;
+  private static final Long TEST_TRACE_ID = -999L;
 
   // Method to clear out any lingering test data that might exist.
   @AfterAll
   @BeforeAll
   public void deleteTestData(){
-    caseSubmissionRepository.deleteByBatchIdAndTraceId(testBatchId, testTraceId);
+    caseSubmissionRepository.deleteByBatchIdAndTraceId(TEST_BATCH_ID, TEST_TRACE_ID);
   }
 
   @Test
   void given_FdcAllRequiredValues_thenSaves(){
     var fdc = createTestFdc();
-    boolean response = eventService.logFdc(EventType.SENT_TO_DRC, testBatchId,testTraceId, fdc, HttpStatus.OK, testPayloadString );
+    boolean response = eventService.logFdc(EventType.SENT_TO_DRC, TEST_BATCH_ID, TEST_TRACE_ID, fdc, HttpStatus.OK, testPayloadString );
     assertTrue(response);
     clearDownData(1L);
   }
 
   @Test
   void given_FdcMinimalValues_thenSaves(){
-    boolean response = eventService.logFdc(EventType.SENT_TO_DRC, testBatchId,testTraceId, null, null, testPayloadString );
+    boolean response = eventService.logFdc(EventType.SENT_TO_DRC, TEST_BATCH_ID, TEST_TRACE_ID, null, null, testPayloadString );
     assertTrue(response);
     clearDownData(1L);
   }
@@ -62,7 +61,7 @@ class DbLoggingTest {
   @Test
   void given_ContributionAllRequiredValues_thenSaves(){
     var contribution = createTestContribution();
-    boolean response = eventService.logConcor(BigInteger.valueOf(-8888), EventType.SENT_TO_DRC,testBatchId,testTraceId, contribution, HttpStatus.OK, testPayloadString );
+    boolean response = eventService.logConcor(-8888L, EventType.SENT_TO_DRC, TEST_BATCH_ID, TEST_TRACE_ID, contribution, HttpStatus.OK, testPayloadString );
     assertTrue(response);
     clearDownData(1L);
   }
@@ -70,33 +69,33 @@ class DbLoggingTest {
   @Test
   void given_MissingTypeValue_thenError(){
     var contribution = createTestContribution();
-    assertThrows(DcesDrcServiceException.class,() -> eventService.logConcor(BigInteger.valueOf(-8888), null, testBatchId,testTraceId, contribution, HttpStatus.OK, testPayloadString ));
+    assertThrows(DcesDrcServiceException.class,() -> eventService.logConcor(-8888L, null, TEST_BATCH_ID, TEST_TRACE_ID, contribution, HttpStatus.OK, testPayloadString ));
     clearDownData(0L);
   }
 
   @Test
   void given_MissingContributionValue_thenSave(){
-    boolean response = eventService.logConcor(BigInteger.valueOf(-8888), EventType.SENT_TO_DRC, testBatchId,testTraceId, null, HttpStatus.OK, testPayloadString );
+    boolean response = eventService.logConcor(-8888L, EventType.SENT_TO_DRC, TEST_BATCH_ID, TEST_TRACE_ID, null, HttpStatus.OK, testPayloadString );
     assertTrue(response);
     clearDownData(1L);
   }
 
   private void clearDownData(Long expectedDeletions){
-    Long deletions = caseSubmissionRepository.deleteByPayloadAndBatchIdAndTraceId(testPayloadString, testBatchId, testTraceId);
+    Long deletions = caseSubmissionRepository.deleteByPayloadAndBatchIdAndTraceId(testPayloadString, TEST_BATCH_ID, TEST_TRACE_ID);
     assertEquals(expectedDeletions, deletions);
   }
 
   private CONTRIBUTIONS createTestContribution(){
     var contribution = new CONTRIBUTIONS();
-    contribution.setId(BigInteger.valueOf(1000));
-    contribution.setMaatId(BigInteger.valueOf(2000));
+    contribution.setId(1000L);
+    contribution.setMaatId(2000L);
     return contribution;
   }
 
   private Fdc createTestFdc(){
     var fdc = new Fdc();
-    fdc.setId(BigInteger.valueOf(1000));
-    fdc.setMaatId(BigInteger.valueOf(2000));
+    fdc.setId(1000L);
+    fdc.setMaatId(2000L);
     return fdc;
   }
 

--- a/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/FdcIntegrationTest.java
+++ b/dces-drc-integration/src/integrationTest/java/uk/gov/justice/laa/crime/dces/integration/testing/FdcIntegrationTest.java
@@ -33,7 +33,6 @@ import uk.gov.justice.laa.crime.dces.integration.service.spy.FdcProcessSpy;
 import uk.gov.justice.laa.crime.dces.integration.service.spy.SpyFactory;
 import uk.gov.justice.laa.crime.dces.integration.service.EventLogAssertService;
 
-import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -70,7 +69,7 @@ class FdcIntegrationTest {
 	ArgumentCaptor<CaseSubmissionEntity> caseSubmissionEntityArgumentCaptor;
 
 	private static final String USER_AUDIT = "DCES";
-	private static final BigInteger testBatchId = BigInteger.valueOf(-555L);
+	private static final Long testBatchId = -555L;
 
 	@Builder
     private record CheckOptions(
@@ -101,7 +100,7 @@ class FdcIntegrationTest {
 	@Test
 	void testProcessFdcUpdateWhenFound() {
 		final var fdcProcessedRequest = FdcProcessedRequest.builder()
-				.fdcId(31774046)
+				.fdcId(31774046L)
 				.build();
 		final Integer response = fdcService.handleFdcProcessedAck(fdcProcessedRequest);
 		softly.assertThat(response).isPositive();
@@ -111,7 +110,7 @@ class FdcIntegrationTest {
 	@Test
 	void testProcessFdcUpdateWhenFoundWithText() {
 		final var fdcProcessedRequest = FdcProcessedRequest.builder()
-				.fdcId(31774046)
+				.fdcId(31774046L)
 				.errorText("testProcessFdcUpdateWhenFoundWithText")
 				.build();
 		final Integer response = fdcService.handleFdcProcessedAck(fdcProcessedRequest);
@@ -123,7 +122,7 @@ class FdcIntegrationTest {
 	void testProcessFdcUpdateWhenNotFound() {
 		final String errorText = "Error Text updated successfully.";
 		final var fdcProcessedRequest = FdcProcessedRequest.builder()
-				.fdcId(9)
+				.fdcId(9L)
 				.errorText(errorText)
 				.build();
 		softly.assertThatThrownBy(() -> fdcService.handleFdcProcessedAck(fdcProcessedRequest))
@@ -134,7 +133,7 @@ class FdcIntegrationTest {
 	// Just verify we're submitting what is expected to the DB. Persistence testing itself is done elsewhere.
 	private void assertProcessFdcCaseSubmissionCreation(FdcProcessedRequest request, HttpStatusCode expectedStatusCode) {
 		CaseSubmissionEntity expectedCaseSubmission = CaseSubmissionEntity.builder()
-				.fdcId(BigInteger.valueOf(request.getFdcId()))
+				.fdcId(request.getFdcId())
 				.payload(request.getErrorText())
 				.eventType(eventLogAssertService.getIdForEventType(EventType.DRC_ASYNC_RESPONSE))
 				.httpStatus(expectedStatusCode.value())

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClient.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClient.java
@@ -18,12 +18,12 @@ import java.util.List;
 public interface ContributionClient extends MaatApiClientBase {
     @GetExchange("/concor-contribution-files")
     List<ConcorContribEntry> getContributions(@RequestParam String status,
-        @RequestParam(name = "concorContributionId") Integer startingId,
+        @RequestParam(name = "concorContributionId") Long startingId,
         @RequestParam Integer numberOfRecords);
 
     @PostExchange("/create-contribution-file")
     @Valid
-    Integer updateContributions(@RequestBody ContributionUpdateRequest contributionUpdateRequest);
+    Long updateContributions(@RequestBody ContributionUpdateRequest contributionUpdateRequest);
 
     @PostExchange("/log-contribution-response")
     @Valid

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/controller/TempTestController.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/controller/TempTestController.java
@@ -25,9 +25,8 @@ import uk.gov.justice.laa.crime.dces.integration.model.ConcorContributionReqForD
 import uk.gov.justice.laa.crime.dces.integration.model.FdcReqForDrc;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile;
 
-import javax.xml.datatype.DatatypeFactory;
 import java.math.BigDecimal;
-import java.math.BigInteger;
+import java.time.LocalDate;
 
 /**
  * This is a simple temporary controller to handle some test endpoints.
@@ -71,9 +70,9 @@ public class TempTestController {
 
     private static FdcFile.FdcList.Fdc fakeFdcObj() {
         FdcFile.FdcList.Fdc fdc = new FdcFile.FdcList.Fdc();
-        fdc.setId(BigInteger.valueOf(94));
-        fdc.setMaatId(BigInteger.valueOf(105));
-        fdc.setSentenceDate(DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar("2023-05-21"));
+        fdc.setId(94L);
+        fdc.setMaatId(105L);
+        fdc.setSentenceDate(LocalDate.parse("2023-05-21"));
         fdc.setCalculationDate(null);
         fdc.setAgfsTotal(null);
         fdc.setLgfsTotal(BigDecimal.valueOf(2000.0));

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/datasource/EventService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/datasource/EventService.java
@@ -14,7 +14,6 @@ import uk.gov.justice.laa.crime.dces.integration.exception.DcesDrcServiceExcepti
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile.FdcList.Fdc;
 
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
 
@@ -34,7 +33,7 @@ public class EventService {
         return caseSubmissionRepository.save(entity);
     }
 
-    public boolean logFdc(EventType eventType, BigInteger batchId, BigInteger traceId, Fdc fdcObject, HttpStatusCode httpStatusCode, String payload){
+    public boolean logFdc(EventType eventType, Long batchId, Long traceId, Fdc fdcObject, HttpStatusCode httpStatusCode, String payload){
         // default fdcObject if null is passed. No ids is a valid scenario.
         fdcObject = Objects.requireNonNullElse(fdcObject, new Fdc());
 
@@ -45,11 +44,11 @@ public class EventService {
         return true;
     }
 
-    public boolean logFdc(EventType eventType, BigInteger batchId, Fdc fdcObject, HttpStatusCode httpStatusCode, String payload){
+    public boolean logFdc(EventType eventType, Long batchId, Fdc fdcObject, HttpStatusCode httpStatusCode, String payload){
         return logFdc(eventType, batchId, null, fdcObject, httpStatusCode, payload);
     }
 
-    public boolean logConcor(BigInteger concorContributionId, EventType eventType, BigInteger batchId, BigInteger traceId, CONTRIBUTIONS contributionsObject, HttpStatusCode httpStatusCode, String payload){
+    public boolean logConcor(Long concorContributionId, EventType eventType, Long batchId, Long traceId, CONTRIBUTIONS contributionsObject, HttpStatusCode httpStatusCode, String payload){
         // default fdcObject if null is passed. No ids is a valid scenario.
         contributionsObject = Objects.requireNonNullElse(contributionsObject, new CONTRIBUTIONS());
 
@@ -60,11 +59,11 @@ public class EventService {
         return true;
     }
 
-    public boolean logConcor(BigInteger concorContributionId, EventType eventType, BigInteger batchId, CONTRIBUTIONS contributionsObject, HttpStatusCode httpStatusCode, String payload){
+    public boolean logConcor(Long concorContributionId, EventType eventType, Long batchId, CONTRIBUTIONS contributionsObject, HttpStatusCode httpStatusCode, String payload){
         return logConcor(concorContributionId, eventType, batchId, null, contributionsObject, httpStatusCode, payload);
     }
 
-    private CaseSubmissionEntity createCaseSubmissionEntity(EventType eventType, BigInteger batchId, BigInteger traceId, BigInteger maatId, HttpStatusCode httpStatusCode, String payload){
+    private CaseSubmissionEntity createCaseSubmissionEntity(EventType eventType, Long batchId, Long traceId, Long maatId, HttpStatusCode httpStatusCode, String payload){
         Integer httpStatus = (Objects.nonNull(httpStatusCode)) ? httpStatusCode.value() : null;
         var caseSubmissionEntity = CaseSubmissionEntity.builder()
                 .batchId(batchId)
@@ -77,10 +76,10 @@ public class EventService {
         return caseSubmissionEntity;
     }
 
-    public BigInteger generateBatchId(){
+    public Long generateBatchId(){
         return caseSubmissionRepository.getNextBatchId();
     }
-    public BigInteger generateTraceId(){
+    public Long generateTraceId(){
         return caseSubmissionRepository.getNextTraceId();
     }
 

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/datasource/model/CaseSubmissionEntity.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/datasource/model/CaseSubmissionEntity.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
-import java.math.BigInteger;
 import java.time.LocalDateTime;
 
 /**
@@ -29,12 +28,12 @@ public class CaseSubmissionEntity {
     @Id
     @SequenceGenerator(name = "case_submission_gen_seq", sequenceName = "case_submission_id_seq", allocationSize = 1)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "case_submission_gen_seq")
-    private BigInteger id;
-    private BigInteger batchId;
-    private BigInteger traceId;
-    private BigInteger maatId;
-    private BigInteger concorContributionId;
-    private BigInteger fdcId;
+    private Long id;
+    private Long batchId;
+    private Long traceId;
+    private Long maatId;
+    private Long concorContributionId;
+    private Long fdcId;
     private String recordType;
     @CreationTimestamp
     private LocalDateTime processedDate;

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/datasource/repository/CaseSubmissionRepository.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/datasource/repository/CaseSubmissionRepository.java
@@ -6,27 +6,26 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.crime.dces.integration.datasource.model.CaseSubmissionEntity;
 
-import java.math.BigInteger;
 import java.util.List;
 
 @Repository
 public interface CaseSubmissionRepository extends JpaRepository<CaseSubmissionEntity, Integer> {
 
     @Query(value = "select nextval('trace_id_seq')", nativeQuery = true)
-    BigInteger getNextTraceId();
+    Long getNextTraceId();
 
     @Query(value = "select nextval('batch_id_seq')", nativeQuery = true)
-    BigInteger getNextBatchId();
+    Long getNextBatchId();
 
     @Transactional
-    Long deleteByPayloadAndBatchIdAndTraceId(String payload, BigInteger batchId, BigInteger traceId);
+    Long deleteByPayloadAndBatchIdAndTraceId(String payload, Long batchId, Long traceId);
 
     @Transactional
-    Long deleteByBatchIdAndTraceId(BigInteger batchId, BigInteger traceId);
+    Long deleteByBatchIdAndTraceId(Long batchId, Long traceId);
 
-    List<CaseSubmissionEntity> findAllByBatchId(BigInteger batchId);
+    List<CaseSubmissionEntity> findAllByBatchId(Long batchId);
 
     @Transactional
-    Long deleteAllByBatchId(BigInteger batchId);
+    Long deleteAllByBatchId(Long batchId);
 
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/model/contributions/ConcorContribEntry.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/model/contributions/ConcorContribEntry.java
@@ -15,6 +15,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ConcorContribEntry {
-    private int concorContributionId;
+    private Long concorContributionId;
     private String xmlContent;
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/model/fdc/FdcContributionEntry.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/maatapi/model/fdc/FdcContributionEntry.java
@@ -20,8 +20,8 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Builder
 public class FdcContributionEntry {
-    private Integer maatId;
-    private Integer id;
+    private Long maatId;
+    private Long id;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate sentenceOrderDate;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
@@ -38,7 +38,7 @@ public class FdcContributionEntry {
     private String accelerate;
     private BigDecimal judApportionPercent;
     private BigDecimal agfsVat;
-    private Integer contFileId;
+    private Long contFileId;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate dateReplaced;
     private FdcContributionsStatus status;

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ConcorContributionAckFromDrc.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ConcorContributionAckFromDrc.java
@@ -5,13 +5,13 @@ import org.springframework.http.ProblemDetail;
 import java.util.Map;
 
 public record ConcorContributionAckFromDrc(ConcorContributionAckData data, Map<String, String> meta) {
-    public record ConcorContributionAckData(int concorContributionId, Integer maatId, ProblemDetail report) {
+    public record ConcorContributionAckData(Long concorContributionId, Long maatId, ProblemDetail report) {
         public String errorText() {
             return ProblemDetails.toErrorText(report);
         }
     }
 
-    public static ConcorContributionAckFromDrc of(final int concorContributionId, final String errorText) {
+    public static ConcorContributionAckFromDrc of(final Long concorContributionId, final String errorText) {
         return new ConcorContributionAckFromDrc(new ConcorContributionAckData(concorContributionId, null,
                 ProblemDetails.fromErrorText(errorText)), Map.of());
     }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ConcorContributionReqForDrc.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ConcorContributionReqForDrc.java
@@ -8,14 +8,14 @@ public record ConcorContributionReqForDrc(ConcorContributionReqData data, Map<St
     /**
      * @param concorContributionObj This field cannot be named `concorContribution` because of Entity Framework used by Advantis.
      */
-    public record ConcorContributionReqData(int concorContributionId, CONTRIBUTIONS concorContributionObj) {
+    public record ConcorContributionReqData(Long concorContributionId, CONTRIBUTIONS concorContributionObj) {
     }
 
-    public static ConcorContributionReqForDrc of(final int concorContributionId, final CONTRIBUTIONS concorContributionObj) {
+    public static ConcorContributionReqForDrc of(final Long concorContributionId, final CONTRIBUTIONS concorContributionObj) {
         return new ConcorContributionReqForDrc(new ConcorContributionReqData(concorContributionId, concorContributionObj), Map.of());
     }
 
-    public static ConcorContributionReqForDrc of(final int concorContributionId, final CONTRIBUTIONS concorContributionObj, final Map<String, String> meta) {
+    public static ConcorContributionReqForDrc of(final Long concorContributionId, final CONTRIBUTIONS concorContributionObj, final Map<String, String> meta) {
         return new ConcorContributionReqForDrc(new ConcorContributionReqData(concorContributionId, concorContributionObj), meta);
     }
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ContributionUpdateRequest.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/ContributionUpdateRequest.java
@@ -5,7 +5,6 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.experimental.SuperBuilder;
 
-import java.math.BigInteger;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
@@ -14,6 +13,6 @@ import java.util.List;
 public class ContributionUpdateRequest extends UpdateRequest{
 
     @NonNull
-    private List<BigInteger> concorContributionIds;
+    private List<Long> concorContributionIds;
 
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/FdcAckFromDrc.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/FdcAckFromDrc.java
@@ -5,13 +5,13 @@ import org.springframework.http.ProblemDetail;
 import java.util.Map;
 
 public record FdcAckFromDrc(FdcAckData data, Map<String, String> meta) {
-    public record FdcAckData(int fdcId, Integer maatId, ProblemDetail report) {
+    public record FdcAckData(Long fdcId, Long maatId, ProblemDetail report) {
         public String errorText() {
             return ProblemDetails.toErrorText(report);
         }
     }
 
-    public static FdcAckFromDrc of(final int fdcId, final String errorText) {
+    public static FdcAckFromDrc of(final Long fdcId, final String errorText) {
         return new FdcAckFromDrc(new FdcAckData(fdcId, null,
                 ProblemDetails.fromErrorText(errorText)), Map.of());
     }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/adapter/LocalDateAdapter.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/adapter/LocalDateAdapter.java
@@ -1,0 +1,15 @@
+package uk.gov.justice.laa.crime.dces.integration.model.adapter;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
+import java.time.LocalDate;
+
+public class LocalDateAdapter extends XmlAdapter<String, LocalDate> {
+    public LocalDate unmarshal(String v) {
+        return LocalDate.parse(v);
+    }
+
+    public String marshal(LocalDate v) {
+        return v.toString();
+    }
+}

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/external/ContributionProcessedRequest.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/external/ContributionProcessedRequest.java
@@ -6,6 +6,6 @@ import lombok.Data;
 @Data
 @Builder
 public class ContributionProcessedRequest {
-    private final Integer concorId;
+    private final Long concorId;
     private final String errorText;
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/external/FdcProcessedRequest.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/model/external/FdcProcessedRequest.java
@@ -6,6 +6,6 @@ import lombok.Data;
 @Data
 @Builder
 public class FdcProcessedRequest {
-    private final Integer fdcId;
+    private final Long fdcId;
     private final String errorText;
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/AnonymisingDataService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/AnonymisingDataService.java
@@ -7,12 +7,9 @@ import org.springframework.util.StringUtils;
 import uk.gov.justice.laa.crime.dces.integration.exception.DcesDrcServiceException;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 
-import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Optional;
-
-import static uk.gov.justice.laa.crime.dces.integration.utils.DateConvertor.convertToXMLGregorianCalendar;
 
 @Slf4j
 @Service
@@ -30,11 +27,11 @@ public class AnonymisingDataService {
             throw new DcesDrcServiceException(e.getMessage(), e);
         }
 
-        secureRandom.setSeed(contribution.getMaatId().longValue());
+        secureRandom.setSeed(contribution.getMaatId());
         faker = new Faker(secureRandom);
 
         if (hasValue(contribution.getMaatId())) {
-            contribution.setMaatId(BigInteger.valueOf(faker.number().numberBetween(100000, 999999)));
+            contribution.setMaatId((long) faker.number().numberBetween(100000, 999999));
         }
         log.info("Anonymising data for contribution with maatId {} and anonymised maat-id: {}", contribution.getMaatId(), contribution.getMaatId());
         Optional.ofNullable(contribution.getApplicant())
@@ -101,7 +98,7 @@ public class AnonymisingDataService {
 
     private void anonymisePersonalDetails(CONTRIBUTIONS.Applicant applicant) {
         Optional.ofNullable(applicant.getId())
-                .ifPresent(id -> applicant.setId(BigInteger.valueOf(faker.number().positive())));
+                .ifPresent(id -> applicant.setId((long)(faker.number().positive())));
         if (hasValue(applicant.getFirstName())) {
             applicant.setFirstName(faker.name().firstName());
         }
@@ -109,7 +106,7 @@ public class AnonymisingDataService {
             applicant.setLastName(faker.name().lastName());
         }
         Optional.ofNullable(applicant.getDob()).ifPresent(dob ->
-                applicant.setDob(convertToXMLGregorianCalendar(faker.timeAndDate().birthday()))
+                applicant.setDob(faker.timeAndDate().birthday())
         );
         if (hasValue(applicant.getNiNumber())) {
             applicant.setNiNumber(faker.idNumber().valid());
@@ -143,7 +140,7 @@ public class AnonymisingDataService {
                 details.setSortCode(String.valueOf(faker.number().numberBetween(100000, 999999)));
             }
             if (hasValue(details.getAccountNo())) {
-                details.setAccountNo(BigInteger.valueOf(faker.number().numberBetween(10000000, 99999999)));
+                details.setAccountNo((long)(faker.number().numberBetween(10000000, 99999999)));
             }
         });
     }
@@ -160,7 +157,7 @@ public class AnonymisingDataService {
                 details.setNiNumber(faker.idNumber().valid());
             }
             Optional.ofNullable(details.getDob()).ifPresent(dob ->
-                    details.setDob(convertToXMLGregorianCalendar(faker.timeAndDate().birthday()))
+                    details.setDob(faker.timeAndDate().birthday())
             );
         });
     }
@@ -251,8 +248,8 @@ public class AnonymisingDataService {
         return StringUtils.hasText(value);
     }
 
-    private boolean hasValue(BigInteger value) {
-        return value != null && value.signum() != 0;
+    private boolean hasValue(Long value) {
+        return value != null && Long.signum(value) != 0;
     }
 
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/ContributionsMapperUtils.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/ContributionsMapperUtils.java
@@ -10,7 +10,6 @@ import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.O
 import javax.xml.transform.stream.StreamSource;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -67,17 +66,17 @@ public class ContributionsMapperUtils extends MapperUtils{
 
     private ContributionFile.Header generateHeader (ObjectFactory of, List<CONTRIBUTIONS> contributionsList, String fileName){
         ContributionFile.Header header = of.createContributionFileHeader();
-        header.setDateGenerated(DateConvertor.convertToXMLGregorianCalendar(LocalDate.now()));
+        header.setDateGenerated(LocalDate.now());
         // TODO: Get generation method for the headers resolved.
         header.setFilename(fileName);
-        header.setId(BigInteger.valueOf(123));
+        header.setId(123L);
         header.setFormatVersion("5");
         header.setRecordCount(getRecordCount(contributionsList));
         return header;
     }
 
-    private static BigInteger getRecordCount(List<CONTRIBUTIONS> contributionsList) {
-        return BigInteger.valueOf(Objects.nonNull(contributionsList) ? contributionsList.size(): 0 );
+    private static Long getRecordCount(List<CONTRIBUTIONS> contributionsList) {
+        return (long) (Objects.nonNull(contributionsList) ? contributionsList.size() : 0);
     }
 
     private ContributionFile.CONTRIBUTIONSLIST generateContributionsList(ObjectFactory of, List<CONTRIBUTIONS> contributionsList){

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/FdcMapperUtils.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/FdcMapperUtils.java
@@ -11,7 +11,6 @@ import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.ObjectFacto
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile.FdcList.Fdc;
 
 import java.io.StringWriter;
-import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -56,16 +55,16 @@ public class FdcMapperUtils extends MapperUtils{
 
     private FdcFile.Header generateHeader (ObjectFactory of, List<Fdc> fdcList){
         FdcFile.Header header = of.createFdcFileHeader();
-        header.setDateGenerated(DateConvertor.convertToXMLGregorianCalendar(LocalDate.now()));
+        header.setDateGenerated(LocalDate.now());
         // TODO: Get generation method for the headers resolved.
         header.setFilename("file.name");
-        header.setFileId(BigInteger.valueOf(123));
+        header.setFileId(123L);
         header.setRecordCount(getRecordCount(fdcList));
         return header;
     }
 
-    private static BigInteger getRecordCount(List<Fdc> contributionsList) {
-        return BigInteger.valueOf(Objects.nonNull(contributionsList) ? contributionsList.size(): 0 );
+    private static Long getRecordCount(List<Fdc> contributionsList) {
+        return (long)(Objects.nonNull(contributionsList) ? contributionsList.size(): 0 );
     }
 
     private FdcFile.FdcList generateFdcList(ObjectFactory of, List<FdcFile.FdcList.Fdc> fdcFileList){
@@ -77,13 +76,13 @@ public class FdcMapperUtils extends MapperUtils{
     public Fdc mapFdcEntry(FdcContributionEntry entry) {
         ObjectFactory of = new ObjectFactory();
         Fdc fdc = of.createFdcFileFdcListFdc();
-        fdc.setId(BigInteger.valueOf(entry.getId()));
-        fdc.setMaatId(BigInteger.valueOf(entry.getMaatId()));
+        fdc.setId(entry.getId());
+        fdc.setMaatId(entry.getMaatId());
         fdc.setLgfsTotal(entry.getLgfsCost());
         fdc.setAgfsTotal(entry.getAgfsCost());
         fdc.setFinalCost(entry.getFinalCost());
-        fdc.setSentenceDate(DateConvertor.convertToXMLGregorianCalendar(entry.getSentenceOrderDate()));
-        fdc.setCalculationDate(DateConvertor.convertToXMLGregorianCalendar(entry.getDateCalculated()));
+        fdc.setSentenceDate(entry.getSentenceOrderDate());
+        fdc.setCalculationDate(entry.getDateCalculated());
         return fdc;
     }
 

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/MapperUtils.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/MapperUtils.java
@@ -8,7 +8,6 @@ import uk.gov.justice.laa.crime.dces.integration.model.generated.ack.CONTRIBUTIO
 import uk.gov.justice.laa.crime.dces.integration.model.generated.ack.ObjectFactory;
 
 import java.io.StringWriter;
-import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
@@ -30,8 +29,8 @@ public class MapperUtils {
         CONTRIBUTIONSFILEACK ackFileObject = ackFactory.createCONTRIBUTIONSFILEACK();
         ackFileObject.setFILENAME(fileName);
         ackFileObject.setDATELOADED(date.format(ackDateGeneratedFormat));
-        ackFileObject.setNOOFRECORDSREJECTED(BigInteger.valueOf(failedLines));
-        ackFileObject.setNOOFRECORDSACCEPTED(BigInteger.valueOf(successfulLines));
+        ackFileObject.setNOOFRECORDSREJECTED(failedLines);
+        ackFileObject.setNOOFRECORDSACCEPTED(successfulLines);
         return mapAckObjectToXML(ackFileObject);
     }
 

--- a/dces-drc-integration/src/main/resources/schemas/bindings_fileACK.xml
+++ b/dces-drc-integration/src/main/resources/schemas/bindings_fileACK.xml
@@ -1,0 +1,8 @@
+<jaxb:bindings xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+               xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               version="3.0" jaxb:extensionBindingPrefixes="xjc">
+    <jaxb:globalBindings>
+        <jaxb:javaType name="java.lang.Integer"
+                       xmlType="xs:integer" />
+    </jaxb:globalBindings>
+</jaxb:bindings>

--- a/dces-drc-integration/src/main/resources/schemas/bindings_general.xml
+++ b/dces-drc-integration/src/main/resources/schemas/bindings_general.xml
@@ -1,0 +1,12 @@
+<jaxb:bindings xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+               xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+               version="3.0" jaxb:extensionBindingPrefixes="xjc">
+    <jaxb:globalBindings>
+        <xjc:javaType name="java.time.LocalDate"
+                      xmlType="xs:date"
+                      adapter="uk.gov.justice.laa.crime.dces.integration.model.adapter.LocalDateAdapter"/>
+        <jaxb:javaType name="java.lang.Long"
+                       xmlType="xs:integer" />
+    </jaxb:globalBindings>
+</jaxb:bindings>

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClientTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClientTest.java
@@ -22,10 +22,8 @@ import uk.gov.justice.laa.crime.dces.integration.config.ServicesProperties;
 import uk.gov.justice.laa.crime.dces.integration.model.ConcorContributionReqForDrc;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
 import java.io.IOException;
-import java.math.BigInteger;
+import java.time.LocalDate;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.failBecauseExceptionWasNotThrown;
@@ -74,9 +72,9 @@ class ContributionClientTest extends ApplicationTestBase {
     }
 
     @Test
-    void test_whenWebClientIsInvoked_thenSuccessfulResponse() throws InterruptedException, DatatypeConfigurationException {
+    void test_whenWebClientIsInvoked_thenSuccessfulResponse() throws InterruptedException {
 
-        ConcorContributionReqForDrc concorContributionReqForDrc = ConcorContributionReqForDrc.of(99, fakeCONTRIBUTIONS());
+        ConcorContributionReqForDrc concorContributionReqForDrc = ConcorContributionReqForDrc.of(99L, fakeCONTRIBUTIONS());
         setupSuccessfulResponse();
         WebClient actualWebClient = maatApiWebClientConfiguration.maatApiWebClient(webClientBuilder, services, oAuth2AuthorizedClientManager);
 
@@ -105,7 +103,7 @@ class ContributionClientTest extends ApplicationTestBase {
     }
 
     private void setupErrorCodeTest(HttpStatus expectedStatus) throws JsonProcessingException, InterruptedException {
-        ConcorContributionReqForDrc concorContributionReqForDrc = ConcorContributionReqForDrc.of(0, new CONTRIBUTIONS());
+        ConcorContributionReqForDrc concorContributionReqForDrc = ConcorContributionReqForDrc.of(0L, new CONTRIBUTIONS());
         setupProblemDetailResponse(fakeProblemDetail(expectedStatus));
         WebClient actualWebClient = maatApiWebClientConfiguration.maatApiWebClient(webClientBuilder, services, oAuth2AuthorizedClientManager);
         try {
@@ -129,16 +127,16 @@ class ContributionClientTest extends ApplicationTestBase {
                 .block();
     }
 
-    private CONTRIBUTIONS fakeCONTRIBUTIONS() throws DatatypeConfigurationException {
+    private CONTRIBUTIONS fakeCONTRIBUTIONS() {
         var factory = new uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.ObjectFactory();
         var contribution = factory.createCONTRIBUTIONS();
-        contribution.setId(BigInteger.valueOf(3333));
-        contribution.setMaatId(BigInteger.valueOf(3338));
+        contribution.setId(3333L);
+        contribution.setMaatId(3338L);
         contribution.setFlag("NEW");
         var applicant = factory.createCONTRIBUTIONSApplicant();
         applicant.setFirstName("John");
         applicant.setLastName("Smith");
-        var cal = DatatypeFactory.newInstance().newXMLGregorianCalendar("1970-12-31");
+        var cal = LocalDate.parse("1970-12-31");
         applicant.setDob(cal);
         applicant.setNiNumber("QQ999999Q");
         contribution.setApplicant(applicant);

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/client/DrcApiClientTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/client/DrcApiClientTest.java
@@ -22,11 +22,9 @@ import uk.gov.justice.laa.crime.dces.integration.model.FdcReqForDrc;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile;
 
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.math.BigInteger;
+import java.time.LocalDate;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.failBecauseExceptionWasNotThrown;
@@ -69,9 +67,9 @@ class DrcApiClientTest extends ApplicationTestBase {
     }
 
     @Test
-    void test_whenWebClientIsInvoked_thenSuccessfulResponse() throws InterruptedException, DatatypeConfigurationException {
+    void test_whenWebClientIsInvoked_thenSuccessfulResponse() throws InterruptedException {
 
-        ConcorContributionReqForDrc concorContributionReqForDrc = ConcorContributionReqForDrc.of(99, fakeCONTRIBUTIONS());
+        ConcorContributionReqForDrc concorContributionReqForDrc = ConcorContributionReqForDrc.of(99L, fakeCONTRIBUTIONS());
         setupSuccessfulResponse();
         WebClient actualWebClient = drcApiWebClientConfiguration.drcApiWebClient(webClientBuilder, services);
 
@@ -84,7 +82,7 @@ class DrcApiClientTest extends ApplicationTestBase {
     @Test
     void test_whenWebClientIsInvokedWithMissingMaatId_thenErrorResponse() throws JsonProcessingException, InterruptedException {
 
-        ConcorContributionReqForDrc concorContributionReqForDrc = ConcorContributionReqForDrc.of(0, new CONTRIBUTIONS());
+        ConcorContributionReqForDrc concorContributionReqForDrc = ConcorContributionReqForDrc.of(0L, new CONTRIBUTIONS());
         setupProblemDetailResponse(fakeProblemDetail());
         WebClient actualWebClient = drcApiWebClientConfiguration.drcApiWebClient(webClientBuilder, services);
         try {
@@ -98,7 +96,7 @@ class DrcApiClientTest extends ApplicationTestBase {
     }
 
     @Test
-    void test_whenFdcWebClientIsInvoked_thenSuccessfulResponse() throws InterruptedException, DatatypeConfigurationException {
+    void test_whenFdcWebClientIsInvoked_thenSuccessfulResponse() throws InterruptedException {
 
         FdcReqForDrc request = FdcReqForDrc.of(99, fakeFdc());
         setupSuccessfulResponse();
@@ -131,7 +129,7 @@ class DrcApiClientTest extends ApplicationTestBase {
     @Test
     void test_whenWebClientIsInvokedWithServerError_thenCorrectErrorThrown() throws JsonProcessingException, InterruptedException {
 
-        ConcorContributionReqForDrc concorContributionReqForDrc = ConcorContributionReqForDrc.of(0, new CONTRIBUTIONS());
+        ConcorContributionReqForDrc concorContributionReqForDrc = ConcorContributionReqForDrc.of(0L, new CONTRIBUTIONS());
         setupProblemDetailResponse(fakeProblemDetailError());
         WebClient actualWebClient = drcApiWebClientConfiguration.drcApiWebClient(webClientBuilder, services);
         try {
@@ -155,16 +153,16 @@ class DrcApiClientTest extends ApplicationTestBase {
                 .block();
     }
 
-    private CONTRIBUTIONS fakeCONTRIBUTIONS() throws DatatypeConfigurationException {
+    private CONTRIBUTIONS fakeCONTRIBUTIONS() {
         var factory = new uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.ObjectFactory();
         var contribution = factory.createCONTRIBUTIONS();
-        contribution.setId(BigInteger.valueOf(3333));
-        contribution.setMaatId(BigInteger.valueOf(3338));
+        contribution.setId(3333L);
+        contribution.setMaatId(3338L);
         contribution.setFlag("NEW");
         var applicant = factory.createCONTRIBUTIONSApplicant();
         applicant.setFirstName("John");
         applicant.setLastName("Smith");
-        var cal = DatatypeFactory.newInstance().newXMLGregorianCalendar("1970-12-31");
+        var cal = LocalDate.parse("1970-12-31");
         applicant.setDob(cal);
         applicant.setNiNumber("QQ999999Q");
         contribution.setApplicant(applicant);
@@ -177,15 +175,15 @@ class DrcApiClientTest extends ApplicationTestBase {
         return contribution;
     }
 
-    private FdcFile.FdcList.Fdc fakeFdc() throws DatatypeConfigurationException {
+    private FdcFile.FdcList.Fdc fakeFdc() {
         var factory = new uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.ObjectFactory();
         var fdc = factory.createFdcFileFdcListFdc();
-        fdc.setId(BigInteger.valueOf(12));
-        fdc.setMaatId(BigInteger.valueOf(16));
+        fdc.setId(12L);
+        fdc.setMaatId(16L);
         fdc.setAgfsTotal(BigDecimal.valueOf(1000.00));
         fdc.setLgfsTotal(BigDecimal.valueOf(2000.00));
         fdc.setFinalCost(BigDecimal.valueOf(3000.00));
-        var cal = DatatypeFactory.newInstance().newXMLGregorianCalendar("2024-09-25");
+        var cal = LocalDate.parse("2024-09-25");
         fdc.setSentenceDate(cal);
         fdc.setCalculationDate(cal);
         return fdc;

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/JacksonConfigurationTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/JacksonConfigurationTest.java
@@ -23,7 +23,7 @@ class JacksonConfigurationTest extends ApplicationTestBase {
 
     @Test
     void givenAConcorContributionReqForDrc_whenItIsSerialized_thenItHasNoNulls() throws JsonProcessingException {
-        var request = ConcorContributionReqForDrc.of(123, new CONTRIBUTIONS(), null);
+        var request = ConcorContributionReqForDrc.of(123L, new CONTRIBUTIONS(), null);
         String json = objectMapper.writeValueAsString(request);
         assertThat(json).doesNotContain("null");
     }

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/MaatApiWebClientConfigurationTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/MaatApiWebClientConfigurationTest.java
@@ -57,8 +57,8 @@ class MaatApiWebClientConfigurationTest extends ApplicationTestBase {
 
     @Test
     void givenAnyParameters_whenMaatApiWebClientIsInvoked_thenTheCorrectWebClientShouldBeReturned() throws JsonProcessingException {
-        ConcorContribEntry expectedResponse = new ConcorContribEntry(1, "xmlContent");
-        expectedResponse.setConcorContributionId(1);
+        ConcorContribEntry expectedResponse = new ConcorContribEntry(1L, "xmlContent");
+        expectedResponse.setConcorContributionId(1L);
         expectedResponse.setXmlContent("xmlContent");
         setupValidResponse(expectedResponse);
 

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/controller/AckFromDrcControllerTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/controller/AckFromDrcControllerTest.java
@@ -52,13 +52,13 @@ class AckFromDrcControllerTest {
     void testContributionWhenDownstreamResponseIsValid() throws Exception {
 
         ContributionProcessedRequest contributionProcessedRequest = ContributionProcessedRequest.builder()
-                .concorId(99)
+                .concorId(99L)
                 .errorText("error 99")
                 .build();
         Integer serviceResponse = 1111;
         when(contributionService.handleContributionProcessedAck(contributionProcessedRequest)).thenReturn(serviceResponse);
 
-        ConcorContributionAckFromDrc concorContributionAckFromDrc = ConcorContributionAckFromDrc.of(99, "error 99");
+        ConcorContributionAckFromDrc concorContributionAckFromDrc = ConcorContributionAckFromDrc.of(99L, "error 99");
         final String requestBody = mapper.writeValueAsString(concorContributionAckFromDrc);
 
         mockMvc.perform(MockMvcRequestBuilders.post(String.format(CONTRIBUTION_URL))
@@ -72,13 +72,13 @@ class AckFromDrcControllerTest {
     void testContributionWhenDownstreamResponseIsNotValid() throws Exception {
 
         ContributionProcessedRequest contributionProcessedRequest = ContributionProcessedRequest.builder()
-                .concorId(9)
+                .concorId(9L)
                 .errorText("Failed to process")
                 .build();
         var serviceResponse = new WebClientResponseException(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         when(contributionService.handleContributionProcessedAck(contributionProcessedRequest)).thenThrow(serviceResponse);
 
-        ConcorContributionAckFromDrc concorContributionAckFromDrc = ConcorContributionAckFromDrc.of(9, "Failed to process");
+        ConcorContributionAckFromDrc concorContributionAckFromDrc = ConcorContributionAckFromDrc.of(9L, "Failed to process");
         final String requestBody = mapper.writeValueAsString(concorContributionAckFromDrc);
 
         mockMvc.perform(MockMvcRequestBuilders.post(String.format(CONTRIBUTION_URL))
@@ -92,12 +92,12 @@ class AckFromDrcControllerTest {
     void testFdcWhenDownstreamResponseIsValid() throws Exception {
 
         FdcProcessedRequest fdcProcessedRequest = FdcProcessedRequest.builder()
-                .fdcId(99)
+                .fdcId(99L)
                 .build();
         Integer serviceResponse = 1111;
         when(fdcService.handleFdcProcessedAck(fdcProcessedRequest)).thenReturn(serviceResponse);
 
-        FdcAckFromDrc fdcAckFromDrc = FdcAckFromDrc.of(99, null);
+        FdcAckFromDrc fdcAckFromDrc = FdcAckFromDrc.of(99L, null);
 
         final String requestBody = mapper.writeValueAsString(fdcAckFromDrc);
 
@@ -112,13 +112,13 @@ class AckFromDrcControllerTest {
     void testFdcWhenDownstreamResponseIsNotValid() throws Exception {
 
         FdcProcessedRequest fdcProcessedRequest = FdcProcessedRequest.builder()
-                .fdcId(9)
+                .fdcId(9L)
                 .errorText("Failed to process")
                 .build();
         var serviceResponse = new WebClientResponseException(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null,null,null);
         when(fdcService.handleFdcProcessedAck(fdcProcessedRequest)).thenThrow(serviceResponse);
 
-        FdcAckFromDrc fdcAckFromDrc = FdcAckFromDrc.of(9, "Failed to process");
+        FdcAckFromDrc fdcAckFromDrc = FdcAckFromDrc.of(9L, "Failed to process");
         final String requestBody = mapper.writeValueAsString(fdcAckFromDrc);
 
         mockMvc.perform(MockMvcRequestBuilders.post(String.format(CONTRIBUTION_FDC_URL))

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/datasource/DatabaseServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/datasource/DatabaseServiceTest.java
@@ -9,8 +9,6 @@ import uk.gov.justice.laa.crime.dces.integration.datasource.model.CaseSubmission
 import uk.gov.justice.laa.crime.dces.integration.datasource.model.RecordType;
 import uk.gov.justice.laa.crime.dces.integration.datasource.repository.CaseSubmissionRepository;
 
-import java.math.BigInteger;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @RequiredArgsConstructor
@@ -38,8 +36,8 @@ class DatabaseServiceTest extends ApplicationTestBase {
 
     private CaseSubmissionEntity createExpectedCaseSubmissionEntity(RecordType recordType, Integer eventTypeId, Integer httpStatusCode) {
         return CaseSubmissionEntity.builder()
-                .fdcId(RecordType.FDC.equals(recordType) ? BigInteger.valueOf(-444) : null)
-                .concorContributionId(RecordType.CONTRIBUTION.equals(recordType) ? BigInteger.valueOf(-333) : null)
+                .fdcId(RecordType.FDC.equals(recordType) ? -444L : null)
+                .concorContributionId(RecordType.CONTRIBUTION.equals(recordType) ? -333L : null)
                 .recordType(recordType.getName())
                 .eventType(eventTypeId)
                 .httpStatus(httpStatusCode)

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/datasource/EventServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/datasource/EventServiceTest.java
@@ -22,7 +22,6 @@ import uk.gov.justice.laa.crime.dces.integration.exception.DcesDrcServiceExcepti
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile.FdcList.Fdc;
 
-import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -45,11 +44,11 @@ class EventServiceTest {
     @Captor
     private ArgumentCaptor<CaseSubmissionEntity> caseSubmissionEntityArgumentCaptor;
 
-    private final BigInteger testTraceId = BigInteger.valueOf(-777);
-    private final BigInteger testBatchId = BigInteger.valueOf(-666);
-    private final BigInteger testMaatId = BigInteger.valueOf(-555);
-    private final BigInteger testFdcId = BigInteger.valueOf(-444);
-    private final BigInteger testConcorId = BigInteger.valueOf(-333);
+    private final Long testTraceId = -777L;
+    private final Long testBatchId = -666L;
+    private final Long testMaatId = -555L;
+    private final Long testFdcId = -444L;
+    private final Long testConcorId = -333L;
     private final String testPayload = "TestPayload"+ LocalDateTime.now();
 
     @Test
@@ -136,19 +135,19 @@ class EventServiceTest {
     @Test
     void whenGenerateBatchIdIsCalled_thenBatchIdIsReturned(){
         when(caseSubmissionRepository.getNextBatchId()).thenReturn(testBatchId);
-        BigInteger actualBatchId = eventService.generateBatchId();
+        Long actualBatchId = eventService.generateBatchId();
         softly.assertThat(actualBatchId).isEqualTo(testBatchId);
         softly.assertAll();
     }
     @Test
     void whenGenerateTraceIdIsCalled_thenBatchIdIsReturned(){
         when(caseSubmissionRepository.getNextTraceId()).thenReturn(testTraceId);
-        BigInteger actualTraceId = eventService.generateTraceId();
+        Long actualTraceId = eventService.generateTraceId();
         softly.assertThat(actualTraceId).isEqualTo(testTraceId);
         softly.assertAll();
     }
 
-    private CaseSubmissionEntity createExpectedCaseSubmissionEntity(RecordType recordType, Integer eventTypeId, BigInteger traceId,HttpStatusCode httpStatusCode){
+    private CaseSubmissionEntity createExpectedCaseSubmissionEntity(RecordType recordType, Integer eventTypeId, Long traceId,HttpStatusCode httpStatusCode){
         return CaseSubmissionEntity.builder()
                 .id(null) // this will not be assigned till post-save.
                 .traceId(traceId)

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/maatapi/ConcorContribEntryTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/maatapi/ConcorContribEntryTest.java
@@ -8,13 +8,13 @@ import uk.gov.justice.laa.crime.dces.integration.maatapi.model.contributions.Con
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @SpringBootTest
 class ConcorContribEntryTest extends ApplicationTestBase {
-    private static final int DEFAULT_ID = 1;
+    private static final Long DEFAULT_ID = 1L;
     private static final String DEFAULT_XML = "XML";
 
 
     @Test
     void givenMaatApiResponse_whenGetIdIsInvoked_thenCorrectIdIsReturned() {
-        int expectedId = 3;
+        Long expectedId = 3L;
         ConcorContribEntry expectedResponse = new ConcorContribEntry(
                 expectedId, DEFAULT_XML
         );
@@ -46,7 +46,7 @@ class ConcorContribEntryTest extends ApplicationTestBase {
 
     @Test
     void givenMaatApiResponse_whenSetIdIsInvoked_thenIdIsUpdated() {
-        int expectedId = 3;
+        Long expectedId = 3L;
         ConcorContribEntry response = new ConcorContribEntry(
                 DEFAULT_ID, DEFAULT_XML
         );

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/AnonymisingDataServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/AnonymisingDataServiceTest.java
@@ -5,13 +5,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 
-import java.math.BigInteger;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static uk.gov.justice.laa.crime.dces.integration.utils.DateConvertor.convertToXMLGregorianCalendar;
 
 class AnonymisingDataServiceTest {
 
@@ -27,9 +25,9 @@ class AnonymisingDataServiceTest {
     @Test
     void testAnonymiseMaatId() {
 
-        BigInteger maatId = BigInteger.valueOf(123456);
+        Long maatId = 123456L;
         CONTRIBUTIONS contributions = new CONTRIBUTIONS();
-        contributions.setMaatId(BigInteger.valueOf(67867));
+        contributions.setMaatId(67867L);
 
         CONTRIBUTIONS result = anonymisingDataService.anonymise(contributions);
 
@@ -41,7 +39,7 @@ class AnonymisingDataServiceTest {
     void testAnonymiseApplicantHomeAddress() {
 
         CONTRIBUTIONS contributions = new CONTRIBUTIONS();
-        contributions.setMaatId(BigInteger.valueOf(123456));
+        contributions.setMaatId(123456L);
         CONTRIBUTIONS.Applicant applicant = new CONTRIBUTIONS.Applicant();
         applicant.setHomeAddress(getApplicantHomeAddress());
         contributions.setApplicant(applicant);
@@ -177,10 +175,10 @@ class AnonymisingDataServiceTest {
 
     private CONTRIBUTIONS.Applicant getApplicant() {
         CONTRIBUTIONS.Applicant applicantWithDefaultData = new CONTRIBUTIONS.Applicant();
-        applicantWithDefaultData.setId(BigInteger.valueOf(1212));
+        applicantWithDefaultData.setId(1212L);
         applicantWithDefaultData.setFirstName("John");
         applicantWithDefaultData.setLastName("Doe");
-        applicantWithDefaultData.setDob(convertToXMLGregorianCalendar(LocalDate.of(1989, 1, 1)));
+        applicantWithDefaultData.setDob(LocalDate.of(1989, 1, 1));
         applicantWithDefaultData.setNiNumber("AB123456C");
         applicantWithDefaultData.setLandline("0123456789");
         applicantWithDefaultData.setMobile("0773456789");
@@ -194,7 +192,7 @@ class AnonymisingDataServiceTest {
 
         CONTRIBUTIONS.Applicant.BankDetails bankDetails = new CONTRIBUTIONS.Applicant.BankDetails();
         bankDetails.setAccountName("John Doe");
-        bankDetails.setAccountNo(BigInteger.valueOf(12345678));
+        bankDetails.setAccountNo(12345678L);
         bankDetails.setSortCode("223344");
         applicantWithDefaultData.setBankDetails(bankDetails);
 
@@ -211,7 +209,7 @@ class AnonymisingDataServiceTest {
         partnerDetails.setFirstName("Jane");
         partnerDetails.setLastName("Doe");
         partnerDetails.setNiNumber("AB123456C");
-        partnerDetails.setDob(convertToXMLGregorianCalendar(LocalDate.of(1980, 1, 1)));
+        partnerDetails.setDob(LocalDate.of(1980, 1, 1));
         applicantWithDefaultData.setPartnerDetails(partnerDetails);
 
         applicantWithDefaultData.setDisabilitySummary(applicantDisabilityData());
@@ -315,7 +313,7 @@ class AnonymisingDataServiceTest {
 
     private CONTRIBUTIONS getContributions() {
         CONTRIBUTIONS contributions = new CONTRIBUTIONS();
-        contributions.setMaatId(BigInteger.valueOf(23223));
+        contributions.setMaatId(23223L);
         return contributions;
     }
 }

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionServiceTest.java
@@ -28,7 +28,6 @@ import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.C
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.ObjectFactory;
 import uk.gov.justice.laa.crime.dces.integration.utils.ContributionsMapperUtils;
 
-import java.math.BigInteger;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -86,7 +85,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 	@MockBean
 	private EventService eventService;
 
-	private final BigInteger testBatchId = BigInteger.valueOf(-666);
+	private final Long testBatchId = -666L;
 
 	@AfterEach
 	void afterTestAssertAll(){
@@ -126,33 +125,33 @@ class ContributionServiceTest extends ApplicationTestBase {
 		verify(eventService, times(30)).logConcor(any(), any(), any(), any(), any(), any());
 		// verify each event is logged.
 		verify(eventService).logConcor(null, EventType.FETCHED_FROM_MAAT, testBatchId, null, OK, "Fetched:5");
-		verify(eventService).logConcor(BigInteger.valueOf(1111), EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(2222), EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(3333), EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(4444), EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(5555), EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(1111L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(2222L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(3333L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(4444L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(5555L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
 		verify(eventService).logConcor(null, EventType.FETCHED_FROM_MAAT, testBatchId, null, OK, "Fetched:3");
-		verify(eventService).logConcor(BigInteger.valueOf(1000), EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(6666), EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(7777), EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(1000L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(6666L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(7777L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
 
-		verify(eventService).logConcor(BigInteger.valueOf(1111), EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(2222), EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(3333), EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(4444), EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(5555), EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(1000), EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(6666), EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(7777), EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(1111L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(2222L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(3333L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(4444L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(5555L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(1000L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(6666L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(7777L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
 
-		verify(eventService).logConcor(BigInteger.valueOf(1111), EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(2222), EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(3333), EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(4444), EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(5555), EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(1000), EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(6666), EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(7777), EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(1111L, EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(2222L, EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(3333L, EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(4444L, EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(5555L, EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(1000L, EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(6666L, EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(7777L, EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
 		verify(eventService).logConcor(null, EventType.UPDATED_IN_MAAT, testBatchId, null, OK, "Successfully Sent:5");
 		verify(eventService).logConcor(null, EventType.UPDATED_IN_MAAT, testBatchId, null, OK, "Successfully Sent:3");
 		verify(eventService, times(2)).logConcor(null, EventType.UPDATED_IN_MAAT, testBatchId, null, OK, "Failed To Send:0");
@@ -270,11 +269,11 @@ class ContributionServiceTest extends ApplicationTestBase {
 		verify(eventService, times(6)).logConcor(any(), any(), any(), any(), any(), any());
 		// verify each event is logged.
 		verify(eventService).logConcor(null, EventType.FETCHED_FROM_MAAT, testBatchId, null, OK, "Fetched:2");
-		verify(eventService).logConcor(BigInteger.valueOf(1234), EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(9876), EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(1234L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(9876L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
 
-		verify(eventService).logConcor(BigInteger.valueOf(1234), EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(BigInteger.valueOf(9876), EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(1234L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(9876L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
 
 		verify(eventService).logConcor(null, EventType.UPDATED_IN_MAAT, testBatchId, null, INTERNAL_SERVER_ERROR, "Failed to create contribution-file: [500 Internal Server Error from POST http://localhost:1111/debt-collection-enforcement/create-contribution-file]");
 
@@ -311,18 +310,18 @@ class ContributionServiceTest extends ApplicationTestBase {
 	@Test
 	void testProcessContributionUpdateWhenSuccessful() {
 		ContributionProcessedRequest dataRequest = ContributionProcessedRequest.builder()
-				.concorId(911)
+				.concorId(911L)
 				.build();
 		Integer response = contributionService.handleContributionProcessedAck(dataRequest);
 		softly.assertThat(response).isEqualTo(1111);
-		verify(eventService).logConcor(BigInteger.valueOf(911),EventType.DRC_ASYNC_RESPONSE,null,null, OK, null);
+		verify(eventService).logConcor(911L,EventType.DRC_ASYNC_RESPONSE,null,null, OK, null);
 	}
 
 	@Test
 	void testProcessContributionUpdateWhenIncomingIsolated() {
 		when(feature.incomingIsolated()).thenReturn(true);
 		ContributionProcessedRequest dataRequest = ContributionProcessedRequest.builder()
-				.concorId(911)
+				.concorId(911L)
 				.build();
 		Integer response = contributionService.handleContributionProcessedAck(dataRequest);
 		softly.assertThat(response).isEqualTo(0); // so MAAT DB not touched
@@ -333,20 +332,20 @@ class ContributionServiceTest extends ApplicationTestBase {
 	void testProcessContributionUpdateWhenFailed() {
 		String errorText = "The request has failed to process";
 		ContributionProcessedRequest dataRequest = ContributionProcessedRequest.builder()
-				.concorId(9)
+				.concorId(9L)
 				.errorText(errorText)
 				.build();
 		var exception = catchThrowableOfType(() -> contributionService.handleContributionProcessedAck(dataRequest), WebClientResponseException.class);
 		softly.assertThat(exception).isNotNull();
 		softly.assertThat(exception.getStatusCode().is4xxClientError()).isTrue();
-		verify(eventService).logConcor(BigInteger.valueOf(9),EventType.DRC_ASYNC_RESPONSE,null,null, BAD_REQUEST, errorText);
+		verify(eventService).logConcor(9L,EventType.DRC_ASYNC_RESPONSE,null,null, BAD_REQUEST, errorText);
 	}
 
 	CONTRIBUTIONS createTestContribution(){
 		ObjectFactory of = new ObjectFactory();
 		CONTRIBUTIONS cont = of.createCONTRIBUTIONS();
-		cont.setMaatId(BigInteger.valueOf(1111));
-		cont.setId(BigInteger.valueOf(3333));
+		cont.setMaatId(1111L);
+		cont.setId(3333L);
 		return cont;
 	}
 }

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/FdcServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/FdcServiceTest.java
@@ -28,8 +28,8 @@ import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile.Fdc
 import uk.gov.justice.laa.crime.dces.integration.utils.FdcMapperUtils;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -53,7 +53,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.laa.crime.dces.integration.utils.DateConvertor.convertToXMLGregorianCalendar;
 
 @ExtendWith(SoftAssertionsExtension.class)
 @WireMockTest(httpPort = 1111)
@@ -83,7 +82,7 @@ class FdcServiceTest extends ApplicationTestBase {
 	@MockBean
 	private EventService eventService;
 
-	private final BigInteger testBatchId = BigInteger.valueOf(-666);
+	private final Long testBatchId = -666L;
 
 	@Captor
 	ArgumentCaptor<Fdc> fdcArgumentCaptor;
@@ -106,8 +105,8 @@ class FdcServiceTest extends ApplicationTestBase {
 		doNothing().when(drcClient).sendFdcReqToDrc(any());
 		when(eventService.generateBatchId()).thenReturn(testBatchId);
 
-		Fdc expectedFdc1 = createExpectedFdc(1000, 10000000, "2050-07-12", "2011-12-03", "3805.69","3805.69", "0");
-		Fdc expectedFdc2 = createExpectedFdc(4000, 40000000, "2000-07-12", "2014-03-20", "2283.1","2283.1", "0");
+		Fdc expectedFdc1 = createExpectedFdc(1000L, 10000000L, "2050-07-12", "2011-12-03", "3805.69","3805.69", "0");
+		Fdc expectedFdc2 = createExpectedFdc(4000L, 40000000L, "2000-07-12", "2014-03-20", "2283.1","2283.1", "0");
 
 		// run
 		boolean successful = fdcService.processDailyFiles();
@@ -184,8 +183,8 @@ class FdcServiceTest extends ApplicationTestBase {
 		customStubs.add(stubFor(post(PREPARE_URL).atPriority(1)
 				.willReturn(serverError())));
 
-		Fdc expectedFdc1 = createExpectedFdc(1000, 10000000, "2050-07-12", "2011-12-03", "3805.69","3805.69", "0");
-		Fdc expectedFdc2 = createExpectedFdc(4000, 40000000, "2000-07-12", "2014-03-20", "2283.1","2283.1", "0");
+		Fdc expectedFdc1 = createExpectedFdc(1000L, 10000000L, "2050-07-12", "2011-12-03", "3805.69","3805.69", "0");
+		Fdc expectedFdc2 = createExpectedFdc(4000L, 40000000L, "2000-07-12", "2014-03-20", "2283.1","2283.1", "0");
 
 
 		// run
@@ -408,7 +407,7 @@ class FdcServiceTest extends ApplicationTestBase {
 	@Test
 	void testProcessFdcUpdateWhenSuccessful() {
 		FdcProcessedRequest dataRequest = FdcProcessedRequest.builder()
-				.fdcId(911)
+				.fdcId(911L)
 				.build();
 		Integer response = fdcService.handleFdcProcessedAck(dataRequest);
 		softly.assertThat(response).isEqualTo(1111);
@@ -418,7 +417,7 @@ class FdcServiceTest extends ApplicationTestBase {
 	void testProcessFdcUpdateWhenIncomingIsolated() {
 		when(feature.incomingIsolated()).thenReturn(true);
 		FdcProcessedRequest dataRequest = FdcProcessedRequest.builder()
-				.fdcId(911)
+				.fdcId(911L)
 				.build();
 		Integer response = fdcService.handleFdcProcessedAck(dataRequest);
 		softly.assertThat(response).isEqualTo(0); // so MAAT DB not touched
@@ -428,7 +427,7 @@ class FdcServiceTest extends ApplicationTestBase {
 	void testProcessFdcUpdateWhenFailed() {
 		String errorText = "The request has failed to process";
 		FdcProcessedRequest dataRequest = FdcProcessedRequest.builder()
-				.fdcId(9)
+				.fdcId(9L)
 				.errorText(errorText)
 				.build();
 		var exception = catchThrowableOfType(() -> fdcService.handleFdcProcessedAck(dataRequest), WebClientResponseException.class);
@@ -440,7 +439,7 @@ class FdcServiceTest extends ApplicationTestBase {
 	void testProcessFdcUpdateWhenServerFailure() {
 		String errorText = "The request has failed to process";
 		FdcProcessedRequest dataRequest = FdcProcessedRequest.builder()
-				.fdcId(500)
+				.fdcId(500L)
 				.errorText(errorText)
 				.build();
 		var exception = catchThrowableOfType(() -> fdcService.handleFdcProcessedAck(dataRequest), WebClientResponseException.class);
@@ -448,12 +447,12 @@ class FdcServiceTest extends ApplicationTestBase {
 		softly.assertThat(exception.getStatusCode().is5xxServerError()).isTrue();
 	}
 
-	Fdc createExpectedFdc(Integer id, Integer maatId, String sentenceDate, String calculationDate, String finalCost, String lgfsTotal, String agfsTotal){
+	Fdc createExpectedFdc(Long id, Long maatId, String sentenceDate, String calculationDate, String finalCost, String lgfsTotal, String agfsTotal){
 		Fdc fdc = new Fdc();
-		fdc.setId(BigInteger.valueOf(id));
-		fdc.setMaatId(BigInteger.valueOf(maatId));
-		fdc.setSentenceDate(convertToXMLGregorianCalendar(sentenceDate));
-		fdc.setCalculationDate(convertToXMLGregorianCalendar(calculationDate));
+		fdc.setId(id);
+		fdc.setMaatId(maatId);
+		fdc.setSentenceDate(LocalDate.parse(sentenceDate));
+		fdc.setCalculationDate(LocalDate.parse(calculationDate));
 		fdc.setFinalCost(new BigDecimal(finalCost));
 		fdc.setLgfsTotal(new BigDecimal(lgfsTotal));
 		fdc.setAgfsTotal(new BigDecimal(agfsTotal));
@@ -470,7 +469,7 @@ class FdcServiceTest extends ApplicationTestBase {
 		softly.assertThat(fdc1.getCalculationDate()).isEqualTo(fdc2.getCalculationDate());
 	}
 
-	private Fdc getFdcFromCaptorByFdcId(BigInteger fdcId){
+	private Fdc getFdcFromCaptorByFdcId(Long fdcId){
 		Optional<Fdc> optionalFdc =  fdcArgumentCaptor.getAllValues().stream().filter(x-> x.getId().equals(fdcId)).findFirst();
 		softly.assertThat(optionalFdc.isPresent()).isTrue();
 		return optionalFdc.get();

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/utils/ContributionsMapperUtilsTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/utils/ContributionsMapperUtilsTest.java
@@ -16,7 +16,6 @@ import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.C
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -75,7 +74,7 @@ class ContributionsMapperUtilsTest extends ApplicationTestBase {
 			fail("Exception occurred in mapping from object to XML:" + e.getMessage());
 		}
 		softly.assertThat(contribution).isNotNull();
-		softly.assertThat(contribution.getId()).isEqualTo(BigInteger.valueOf(222769650));
+		softly.assertThat(contribution.getId()).isEqualTo(222769650L);
 		softly.assertThat(contribution.getFlag()).isEqualTo(UPDATE);
 	}
 
@@ -96,7 +95,7 @@ class ContributionsMapperUtilsTest extends ApplicationTestBase {
 		String generatedXML = contributionsMapperUtils.generateFileXML(cl,"filename");
 
 		softly.assertThat(contribution).isNotNull();
-		softly.assertThat(contribution.getId()).isEqualTo(BigInteger.valueOf(222769650));
+		softly.assertThat(contribution.getId()).isEqualTo(222769650L);
 		softly.assertThat(contribution.getFlag()).isEqualTo(UPDATE);
 		softly.assertThat(generatedXML).isNotNull();
 		softly.assertThat(generatedXML.length()>0).isTrue();

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/utils/FdcMapperUtilsTests.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/utils/FdcMapperUtilsTests.java
@@ -12,9 +12,7 @@ import uk.gov.justice.laa.crime.dces.integration.maatapi.model.fdc.FdcContributi
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile.FdcList.Fdc;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.ObjectFactory;
 
-import javax.xml.datatype.XMLGregorianCalendar;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,8 +20,8 @@ import java.util.List;
 @ExtendWith(SoftAssertionsExtension.class)
 class FdcMapperUtilsTests extends ApplicationTestBase {
 
-	private static final BigInteger DEFAULT_ID = BigInteger.valueOf(111111);
-	private static final BigInteger DEFAULT_MAAT_ID = BigInteger.valueOf(222222);
+	private static final Long DEFAULT_ID = 111111L;
+	private static final Long DEFAULT_MAAT_ID = 222222L;
 	private static final BigDecimal DEFAULT_AGFS_TOTAL = BigDecimal.valueOf(200.00);
 	private static final BigDecimal DEFAULT_FINAL_COST = BigDecimal.valueOf(300.00);
 	private static final BigDecimal DEFAULT_LGFS_TOTAL = BigDecimal.valueOf(400.00);
@@ -51,8 +49,8 @@ class FdcMapperUtilsTests extends ApplicationTestBase {
 		softly.assertThat(mappedFdc.getAgfsTotal()).isEqualTo(DEFAULT_AGFS_TOTAL);
 		softly.assertThat(mappedFdc.getLgfsTotal()).isEqualTo(DEFAULT_LGFS_TOTAL);
 		softly.assertThat(mappedFdc.getFinalCost()).isEqualTo(DEFAULT_FINAL_COST);
-		softly.assertThat(getLocalDate(mappedFdc.getCalculationDate())).isEqualTo(testInput.getDateCalculated());
-		softly.assertThat(getLocalDate(mappedFdc.getSentenceDate())).isEqualTo(testInput.getSentenceOrderDate());
+		softly.assertThat(mappedFdc.getCalculationDate()).isEqualTo(testInput.getDateCalculated());
+		softly.assertThat(mappedFdc.getSentenceDate()).isEqualTo(testInput.getSentenceOrderDate());
 
 	}
 
@@ -73,8 +71,8 @@ class FdcMapperUtilsTests extends ApplicationTestBase {
 	}
 
 	private Fdc generateDefaultFdc() {
-		XMLGregorianCalendar calculationDate = DateConvertor.convertToXMLGregorianCalendar(LocalDate.parse(DEFAULT_CALCULATION_DATE));
-		XMLGregorianCalendar sentenceDate = DateConvertor.convertToXMLGregorianCalendar(LocalDate.parse(DEFAULT_SENTENCE_DATE));
+		LocalDate calculationDate = LocalDate.parse(DEFAULT_CALCULATION_DATE);
+		LocalDate sentenceDate = LocalDate.parse(DEFAULT_SENTENCE_DATE);
 		ObjectFactory of = new ObjectFactory();
 		Fdc fdc = of.createFdcFileFdcListFdc();
 		fdc.setId(DEFAULT_ID);
@@ -89,20 +87,13 @@ class FdcMapperUtilsTests extends ApplicationTestBase {
 
 	private FdcContributionEntry generateDefaultFdcEntry(){
 		return FdcContributionEntry.builder()
-				.id(DEFAULT_ID.intValue())
-				.maatId(DEFAULT_MAAT_ID.intValue())
+				.id(DEFAULT_ID)
+				.maatId(DEFAULT_MAAT_ID)
 				.agfsCost(DEFAULT_AGFS_TOTAL)
 				.lgfsCost(DEFAULT_LGFS_TOTAL)
 				.finalCost(DEFAULT_FINAL_COST)
 				.dateCalculated(LocalDate.parse(DEFAULT_CALCULATION_DATE))
 				.sentenceOrderDate(LocalDate.parse(DEFAULT_SENTENCE_DATE)).build();
-	}
-
-	private LocalDate getLocalDate(XMLGregorianCalendar gregorianCalendar){
-		return LocalDate.of(
-				gregorianCalendar.getYear(),
-				gregorianCalendar.getMonth(),
-				gregorianCalendar.getDay());
 	}
 
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-608)

Changed XSD->Object generation to create Longs instead of BigDecimals.
Changed Maat API calls to be populated with Longs, what they have their side is irrelevant.
Changed DCES DB calls to use Longs. 

Refactored all tests and code to keep this consistency. 
Added .env files to the git ignore list.

## Checklist

Before you ask people to review this PR:

- [ ] You have populated this PR ticket with relevant information.
- [ ] Tests should be passing: `./gradlew test`
- [ ] Has been deployed to DEV successfully, and Integration Tests have been successful. `./gradlew integrationTest`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
