### PR TITLE
OAuth changes to make drc-client work from non-request context

### DIFF
--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClientTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/client/ContributionClientTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
@@ -43,6 +44,7 @@ class ContributionClientTest extends ApplicationTestBase {
     @Autowired
     private ObjectMapper mapper;
 
+    @Qualifier("maatApiAuthorizedClientManager")
     @Autowired
     private OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
 

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/MaatApiWebClientConfigurationTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/config/MaatApiWebClientConfigurationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
@@ -37,6 +38,7 @@ class MaatApiWebClientConfigurationTest extends ApplicationTestBase {
     @Autowired
     private ServicesProperties services;
 
+    @Qualifier("maatApiAuthorizedClientManager")
     @MockBean
     OAuth2AuthorizedClientManager authorizedClientManager;
 


### PR DESCRIPTION
## What

OAuth changes to make drc-client work from non-request context
- Default manager tries to access the principal from the request, which doesn't work in a cron scheduled job.

## Checklist

Before you ask people to review this PR:

- [X] You have populated this PR ticket with relevant information.
- [X] Tests should be passing: `./gradlew test`
- [ ] Has been deployed to DEV successfully, and Integration Tests have been successful. `./gradlew integrationTest`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
