### PR TITLE
Remove required attribute from letter id property

### DIFF
--- a/dces-drc-integration/src/main/resources/schemas/concorContribution.opt.schema.json
+++ b/dces-drc-integration/src/main/resources/schemas/concorContribution.opt.schema.json
@@ -594,7 +594,6 @@
     },
     "CONTRIBUTIONS.Correspondence.Letter": {
       "type": "object",
-      "required": ["id"],
       "properties": {
         "ref": { "type": "string" },
         "id": { "type": "integer" },


### PR DESCRIPTION
## What

Removed required attribute from the correspondence.letter.id property, as we have found (likely historical) examples that omit the id.

## Checklist

Before you ask people to review this PR:

- [X] You have populated this PR ticket with relevant information.
- [X] Tests should be passing: `./gradlew test`
- [X] Has been deployed to DEV successfully, and Integration Tests have been successful. `./gradlew integrationTest`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
