### PR TITLE
DCES-689-200-Response-Persistence

### DIFF
--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/DrcClient.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/client/DrcClient.java
@@ -10,8 +10,8 @@ import uk.gov.justice.laa.crime.dces.integration.model.FdcReqForDrc;
 @HttpExchange
 public interface DrcClient {
     @PostExchange("/laa/v1/contribution")
-    void sendConcorContributionReqToDrc(@NotNull @RequestBody ConcorContributionReqForDrc request);
+    String sendConcorContributionReqToDrc(@NotNull @RequestBody ConcorContributionReqForDrc request);
 
     @PostExchange("/laa/v1/fdc")
-    void sendFdcReqToDrc(@NotNull @RequestBody FdcReqForDrc request);
+    String sendFdcReqToDrc(@NotNull @RequestBody FdcReqForDrc request);
 }

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/MigrationService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/MigrationService.java
@@ -181,10 +181,12 @@ public class MigrationService {
             Fdc currentFdc;
             try {
                 currentFdc = fdcMap.get(currentMigrationEntity.getFdcId());
+                String responsePayload = null;
                 if( !feature.outgoingIsolated() ) {
                     var request = FdcReqForDrc.of(currentFdc.getId().intValue(), currentFdc, Map.of("migrated", "true"));
-                    drcClient.sendFdcReqToDrc(request);
+                    responsePayload = drcClient.sendFdcReqToDrc(request);
                 }
+                currentMigrationEntity.setPayload(responsePayload);
                 currentMigrationEntity.setProcessed(true);
                 currentMigrationEntity.setProcessedDate(LocalDateTime.now());
             } catch (WebClientResponseException e) {
@@ -231,10 +233,12 @@ public class MigrationService {
             }
             try {
                 CONTRIBUTIONS contribution = mapToContribution(currentConcorXML, unmarshaller);
+                String response = null;
                 if( !feature.outgoingIsolated() ) {
                     var request = ConcorContributionReqForDrc.of(currentMigrationEntity.getConcorContributionId(), contribution, Map.of("migrated", "true"));
-                    drcClient.sendConcorContributionReqToDrc(request);
+                    response = drcClient.sendConcorContributionReqToDrc(request);
                 }
+                currentMigrationEntity.setPayload(response);
                 currentMigrationEntity.setProcessed(true);
                 currentMigrationEntity.setProcessedDate(LocalDateTime.now());
             } catch (WebClientResponseException e) {

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionServiceTest.java
@@ -47,7 +47,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.intThat;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -91,6 +90,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 	private EventService eventService;
 
 	private final Long testBatchId = -666L;
+	private final String testDrcResponsePayload = "TestPayload";
 
 	@AfterEach
 	void afterTestAssertAll(){
@@ -117,7 +117,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("ValidXML");
 		when(contributionsMapperUtils.generateFileName(any())).thenReturn("TestFilename.xml");
 		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
-		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
+		when(drcClient.sendConcorContributionReqToDrc(any())).thenReturn(testDrcResponsePayload);
 
 		boolean result = contributionService.processDailyFiles();
 		//testing the number of times the methods are called to ensure the correct number of records are processed.
@@ -140,14 +140,14 @@ class ContributionServiceTest extends ApplicationTestBase {
 		verify(eventService).logConcor(6666L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
 		verify(eventService).logConcor(7777L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
 
-		verify(eventService).logConcor(1111L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(2222L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(3333L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(4444L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(5555L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(1000L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(6666L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(7777L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(1111L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, testDrcResponsePayload);
+		verify(eventService).logConcor(2222L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, testDrcResponsePayload);
+		verify(eventService).logConcor(3333L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, testDrcResponsePayload);
+		verify(eventService).logConcor(4444L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, testDrcResponsePayload);
+		verify(eventService).logConcor(5555L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, testDrcResponsePayload);
+		verify(eventService).logConcor(1000L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, testDrcResponsePayload);
+		verify(eventService).logConcor(6666L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, testDrcResponsePayload);
+		verify(eventService).logConcor(7777L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, testDrcResponsePayload);
 
 		verify(eventService).logConcor(1111L, EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
 		verify(eventService).logConcor(2222L, EventType.UPDATED_IN_MAAT, testBatchId, testContribution, OK, null);
@@ -171,7 +171,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("ValidXML");
 		when(contributionsMapperUtils.generateFileName(any())).thenReturn("TestFilename.xml");
 		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
-		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
+		when(drcClient.sendConcorContributionReqToDrc(any())).thenReturn(testDrcResponsePayload);
 
 		boolean result = contributionService.processDailyFiles();
 		//testing the number of times the methods are called to ensure the correct number of records are processed.
@@ -189,7 +189,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("ValidXML");
 		when(contributionsMapperUtils.generateFileName(any())).thenReturn("TestFilename.xml");
 		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
-		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
+		when(drcClient.sendConcorContributionReqToDrc(any())).thenReturn(testDrcResponsePayload);
 		when(feature.outgoingAnonymized()).thenReturn(false);
 
 		contributionService.processDailyFiles();
@@ -204,7 +204,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("ValidXML");
 		when(contributionsMapperUtils.generateFileName(any())).thenReturn("TestFilename.xml");
 		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
-		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
+		when(drcClient.sendConcorContributionReqToDrc(any())).thenReturn(testDrcResponsePayload);
 		when(feature.outgoingAnonymized()).thenReturn(true);
 
 		contributionService.processDailyFiles();
@@ -219,7 +219,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("ValidXML");
 		when(contributionsMapperUtils.generateFileName(any())).thenReturn("TestFilename.xml");
 		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
-		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
+		when(drcClient.sendConcorContributionReqToDrc(any())).thenReturn(testDrcResponsePayload);
 
 		boolean result = contributionService.processDailyFiles();
 		verify(contributionsMapperUtils, times(2)).mapLineXMLToObject(any());
@@ -259,7 +259,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("InvalidXML");
 		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("AckXML");
 		when(contributionsMapperUtils.generateFileName(any())).thenReturn("FileName");
-		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
+		when(drcClient.sendConcorContributionReqToDrc(any())).thenReturn(testDrcResponsePayload);
 		when(eventService.generateBatchId()).thenReturn(testBatchId);
 
 		softly.assertThatThrownBy(() -> contributionService.processDailyFiles())
@@ -276,8 +276,8 @@ class ContributionServiceTest extends ApplicationTestBase {
 		verify(eventService).logConcor(1234L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
 		verify(eventService).logConcor(9876L, EventType.FETCHED_FROM_MAAT, testBatchId, testContribution, OK, null);
 
-		verify(eventService).logConcor(1234L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
-		verify(eventService).logConcor(9876L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, null);
+		verify(eventService).logConcor(1234L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, testDrcResponsePayload);
+		verify(eventService).logConcor(9876L, EventType.SENT_TO_DRC, testBatchId, testContribution, OK, testDrcResponsePayload);
 
 		verify(eventService).logConcor(null, EventType.UPDATED_IN_MAAT, testBatchId, null, INTERNAL_SERVER_ERROR, "Failed to create contribution-file: Message:[500 Internal Server Error from POST http://localhost:1111/debt-collection-enforcement/create-contribution-file] | Response:[{\"files\":[]}]");
 
@@ -302,7 +302,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 		when(contributionsMapperUtils.generateFileXML(any(), any())).thenReturn("ValidXML");
 		when(contributionsMapperUtils.generateFileName(any())).thenReturn("TestFilename.xml");
 		when(contributionsMapperUtils.generateAckXML(any(), any(), any(), any())).thenReturn("ValidAckXML");
-		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
+		when(drcClient.sendConcorContributionReqToDrc(any())).thenReturn(testDrcResponsePayload);
 		// do
 		softly.assertThatThrownBy(() -> contributionService.processDailyFiles())
 				.isInstanceOf(WebClientResponseException.class);
@@ -362,7 +362,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 	void givenIdList_whenSendContributionsToDrcIsCalled_thenXmlIsFetchedAndSent() throws JAXBException {
 		when(feature.outgoingIsolated()).thenReturn(false);
 		when(contributionsMapperUtils.mapLineXMLToObject(any())).thenReturn(createTestContribution());
-		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
+		when(drcClient.sendConcorContributionReqToDrc(any())).thenReturn(testDrcResponsePayload);
 
 		List<ConcorContribEntry> result = contributionService.sendContributionsToDrc(List.of(1L, 2L));
 		verify(contributionsMapperUtils, times(2)).mapLineXMLToObject(any());
@@ -379,7 +379,7 @@ class ContributionServiceTest extends ApplicationTestBase {
 	void givenEmptyIdList_whenSendContributionsToDrcIsCalled_thenErrorIsReturned() throws JAXBException {
 		when(feature.outgoingIsolated()).thenReturn(false);
 		when(contributionsMapperUtils.mapLineXMLToObject(any())).thenReturn(createTestContribution());
-		doNothing().when(drcClient).sendConcorContributionReqToDrc(any());
+		when(drcClient.sendConcorContributionReqToDrc(any())).thenReturn(testDrcResponsePayload);
 		softly.assertThatThrownBy(() -> contributionService.sendContributionsToDrc(List.of()))
 				.isInstanceOf(BadRequest.class)
 				.hasMessageContaining("400 Bad Request");


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-689)

Adding persistance of the response to the sendToDrc calls. Basic String in order to persist the whole response, regardless of type/formatting.

## Checklist

Before you ask people to review this PR:

- [x] You have populated this PR ticket with relevant information.
- [x] Tests should be passing: `./gradlew test`
- [x] Has been deployed to DEV successfully, and Integration Tests have been successful. `./gradlew integrationTest`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
