### PR TITLE
DCES-710-Unique Drc Conflict Code

### DIFF
--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
@@ -160,14 +160,14 @@ public class ContributionService implements FileService {
             if (Objects.nonNull(currentContribution)) {
                 try {
                     String response = executeSendConcorToDrcCall(concorContributionId, currentContribution, failedContributions);
-                    int pseudoStatusCode = ContributionsMapperUtils.mapDRCJsonResponseToHttpStatus(response);
+                    HttpStatusCode pseudoStatusCode = ContributionsMapperUtils.mapDRCJsonResponseToHttpStatus(response);
                     if (MapperUtils.successfulStatus(pseudoStatusCode)) {
-                        eventService.logConcor(concorContributionId, SENT_TO_DRC, batchId, currentContribution, HttpStatusCode.valueOf(pseudoStatusCode), response);
+                        eventService.logConcor(concorContributionId, SENT_TO_DRC, batchId, currentContribution, pseudoStatusCode, response);
                         successfulContributions.put(concorContributionId, currentContribution);
                     } else {
                         // if we didn't get a valid response, record an error status code 635, and try again next time.
                         failedContributions.put(concorContributionId, "Invalid JSON response body from DRC");
-                        eventService.logConcor(concorContributionId, SENT_TO_DRC, batchId, currentContribution, HttpStatusCode.valueOf(pseudoStatusCode), response);
+                        eventService.logConcor(concorContributionId, SENT_TO_DRC, batchId, currentContribution, pseudoStatusCode, response);
                     }
                 } catch (WebClientResponseException e) {
                     if (FileServiceUtils.isDrcConflict(e)) {

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/ContributionService.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.OK;
 import static uk.gov.justice.laa.crime.dces.integration.datasource.model.EventType.DRC_ASYNC_RESPONSE;
@@ -173,7 +172,7 @@ public class ContributionService implements FileService {
                 } catch (WebClientResponseException e) {
                     if (FileServiceUtils.isDrcConflict(e)) {
                         log.info("Ignoring duplicate contribution error response from DRC, concorContributionId = {}, maatId = {}", concorContributionId, currentContribution.getMaatId());
-                        eventService.logConcor(concorContributionId, SENT_TO_DRC, batchId, currentContribution, CONFLICT, e.getResponseBodyAsString());
+                        eventService.logConcor(concorContributionId, SENT_TO_DRC, batchId, currentContribution, MapperUtils.STATUS_CONFLICT_DUPLICATE_ID, e.getResponseBodyAsString());
                         successfulContributions.put(concorContributionId, currentContribution);
                     } else {
                         // If unsuccessful, then keep track in order to populate the ack details in the MAAT API Call.

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.OK;
 import static uk.gov.justice.laa.crime.dces.integration.datasource.model.EventType.DRC_ASYNC_RESPONSE;
@@ -203,7 +202,7 @@ public class FdcService implements FileService {
             } catch (WebClientResponseException e){
                 if (FileServiceUtils.isDrcConflict(e)) {
                     log.info("Ignoring duplicate FDC error response from DRC, fdcId = {}, maatId = {}", currentFdc.getId(), currentFdc.getMaatId());
-                    eventService.logFdc(SENT_TO_DRC, batchId, currentFdc, CONFLICT, e.getResponseBodyAsString());
+                    eventService.logFdc(SENT_TO_DRC, batchId, currentFdc, MapperUtils.STATUS_CONFLICT_DUPLICATE_ID, e.getResponseBodyAsString());
                     successfulFdcs.add(currentFdc);
                 } else {
                     // if not CONFLICT, or not duplicate, then just log it.

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/service/FdcService.java
@@ -190,14 +190,14 @@ public class FdcService implements FileService {
             int fdcId = currentFdc.getId().intValue();
             try {
                 String responsePayload = executeSendFdcToDrcCall(currentFdc, fdcId, failedFdcs);
-                int pseudoStatusCode = FdcMapperUtils.mapDRCJsonResponseToHttpStatus(responsePayload);
+                HttpStatusCode pseudoStatusCode = FdcMapperUtils.mapDRCJsonResponseToHttpStatus(responsePayload);
                 if (MapperUtils.successfulStatus(pseudoStatusCode)) {
-                    eventService.logFdc(SENT_TO_DRC, batchId, currentFdc, HttpStatusCode.valueOf(pseudoStatusCode), responsePayload);
+                    eventService.logFdc(SENT_TO_DRC, batchId, currentFdc, pseudoStatusCode, responsePayload);
                     successfulFdcs.add(currentFdc);
                 } else {
                     // if we didn't get a valid response, record an error status code 635, and try again next time.
                     failedFdcs.put(currentFdc.getId(), "Invalid JSON response body from DRC");
-                    eventService.logFdc(SENT_TO_DRC, batchId, currentFdc, HttpStatusCode.valueOf(pseudoStatusCode), responsePayload);
+                    eventService.logFdc(SENT_TO_DRC, batchId, currentFdc, pseudoStatusCode, responsePayload);
                 }
             } catch (WebClientResponseException e){
                 if (FileServiceUtils.isDrcConflict(e)) {

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/ContributionsMapperUtils.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/ContributionsMapperUtils.java
@@ -7,6 +7,7 @@ import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.ContributionFile;
@@ -95,7 +96,7 @@ public class ContributionsMapperUtils extends MapperUtils{
      *         632 if the response body is faked because feature.outgoing-isolated is enabled,
      *         635 if the response body is invalid.
      */
-    public static int mapDRCJsonResponseToHttpStatus(String jsonString){
+    public static HttpStatusCode mapDRCJsonResponseToHttpStatus(String jsonString){
         JsonNode jsonNode = mapDRCJsonResponseToJsonNode(jsonString);
         if (checkDrcId(jsonNode) && checkConcorContributionId(jsonNode)) {
             if (checkSkipped(jsonNode)) {

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/FdcMapperUtils.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/FdcMapperUtils.java
@@ -5,6 +5,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.model.fdc.FdcContributionEntry;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile;
@@ -90,7 +91,7 @@ public class FdcMapperUtils extends MapperUtils{
      *         632 if the response body is faked because feature.outgoing-isolated is enabled,
      *         635 if the response body is invalid.
      */
-    public static int mapDRCJsonResponseToHttpStatus(String jsonString){
+    public static HttpStatusCode mapDRCJsonResponseToHttpStatus(String jsonString){
         JsonNode jsonNode = mapDRCJsonResponseToJsonNode(jsonString);
         if (checkDrcId(jsonNode) && checkFdcId(jsonNode)) {
             if (checkSkipped(jsonNode)) {

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/MapperUtils.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/MapperUtils.java
@@ -20,13 +20,13 @@ import java.util.Objects;
 @Slf4j
 public class MapperUtils {
     /** Response body is valid JSON "meta" element that includes a positive "drcId" and "concorContributionId" or "fdcId" attribute. */
-    public static final int STATUS_OK_VALID = 200;
+    public static final HttpStatusCode STATUS_OK_VALID = HttpStatusCode.valueOf(200);
     /** Response body is valid JSON "meta" element but has been faked because feature.outgoing-isolated is enabled. */
-    public static final int STATUS_OK_SKIPPED = 632;
+    public static final HttpStatusCode STATUS_OK_SKIPPED = HttpStatusCode.valueOf(632);
     /** Response is a 409 Conflict, which is due to the fdc/concor id being already sent to the DRC */
     public static final HttpStatusCode STATUS_CONFLICT_DUPLICATE_ID = HttpStatusCode.valueOf(634);
     /** Response body is either not valid JSON, or is missing required elements. */
-    public static final int STATUS_OK_INVALID = 635;
+    public static final HttpStatusCode STATUS_OK_INVALID = HttpStatusCode.valueOf(635);
 
     private final Marshaller ackMarshaller;
     protected final DateTimeFormatter filenameFormat = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
@@ -73,8 +73,8 @@ public class MapperUtils {
         return skipped.isValueNode() && skipped.asBoolean();
     }
 
-    public static boolean successfulStatus(int pseudoStatusCode) {
-        return pseudoStatusCode == STATUS_OK_VALID || pseudoStatusCode == STATUS_OK_SKIPPED;
+    public static boolean successfulStatus(HttpStatusCode pseudoStatusCode) {
+        return STATUS_OK_VALID.equals(pseudoStatusCode) || STATUS_OK_SKIPPED.equals(pseudoStatusCode);
     }
 
     /**

--- a/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/MapperUtils.java
+++ b/dces-drc-integration/src/main/java/uk/gov/justice/laa/crime/dces/integration/utils/MapperUtils.java
@@ -8,6 +8,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.ack.CONTRIBUTIONSFILEACK;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.ack.ObjectFactory;
 
@@ -22,6 +23,8 @@ public class MapperUtils {
     public static final int STATUS_OK_VALID = 200;
     /** Response body is valid JSON "meta" element but has been faked because feature.outgoing-isolated is enabled. */
     public static final int STATUS_OK_SKIPPED = 632;
+    /** Response is a 409 Conflict, which is due to the fdc/concor id being already sent to the DRC */
+    public static final HttpStatusCode STATUS_CONFLICT_DUPLICATE_ID = HttpStatusCode.valueOf(634);
     /** Response body is either not valid JSON, or is missing required elements. */
     public static final int STATUS_OK_INVALID = 635;
 
@@ -93,4 +96,5 @@ public class MapperUtils {
         }
         return JsonNodeFactory.instance.missingNode();
     }
+
 }

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/FdcServiceTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/service/FdcServiceTest.java
@@ -28,6 +28,7 @@ import uk.gov.justice.laa.crime.dces.integration.datasource.model.EventType;
 import uk.gov.justice.laa.crime.dces.integration.model.external.FdcProcessedRequest;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile.FdcList.Fdc;
 import uk.gov.justice.laa.crime.dces.integration.utils.FdcMapperUtils;
+import uk.gov.justice.laa.crime.dces.integration.utils.MapperUtils;
 
 import java.math.BigDecimal;
 import java.net.URI;
@@ -408,6 +409,36 @@ class FdcServiceTest extends ApplicationTestBase {
 		WireMock.verify(1, postRequestedFor(urlEqualTo(PREPARE_URL)));
 		WireMock.verify(1, getRequestedFor(urlEqualTo(GET_URL)));
 		verify(drcClient, times(12)).sendFdcReqToDrc(any());
+
+		verify(eventService, times(12)).logFdc(eq(EventType.SENT_TO_DRC), any(), any(), eq(MapperUtils.STATUS_CONFLICT_DUPLICATE_ID), any());
+		WireMock.verify(1, postRequestedFor(urlEqualTo(UPDATE_URL)));
+		verify(fdcMapperUtils,times(1)).generateFileXML(any(),any());
+	}
+
+	@Test
+	void testDrcUpdateWebClientNonDRCConflictException() {
+		// setup
+		when(fdcMapperUtils.mapFdcEntry(any())).thenCallRealMethod();
+		when(fdcMapperUtils.generateFileXML(any(),any())).thenReturn("<xml>ValidXML</xml>");
+		when(fdcMapperUtils.generateFileName(any())).thenReturn("Test.xml");
+		when(fdcMapperUtils.generateAckXML(anyString(), any(), intThat(n -> n != 0), anyInt())).thenThrow(new IllegalStateException("failed != 0"));
+		when(fdcMapperUtils.generateAckXML(anyString(), any(), eq(0), anyInt())).thenReturn("<xml>ValidAckXML</xml>");
+		// Setting WebClientResponseException body & MIME type is not enough for `#getResponseAs(Class)` to work.
+		// There's also a non-blocking `bodyDecodeFunction` set by `ClientResponse.createException()`/`createError()`.
+		var problemDetail = ProblemDetail.forStatus(409);
+		problemDetail.setType(URI.create("https://generic.conflict/problem-types#duplicate-id"));
+		var exception = new WebClientResponseException(409, "Conflict", null, null, null);
+		exception.setBodyDecodeFunction(clazz -> clazz.isAssignableFrom(ProblemDetail.class) ? problemDetail : null);
+		Mockito.doThrow(exception).when(drcClient).sendFdcReqToDrc(any());
+		// do
+		boolean successful = fdcService.processDailyFiles();
+		// test
+		softly.assertThat(successful).isTrue();
+		WireMock.verify(1, postRequestedFor(urlEqualTo(PREPARE_URL)));
+		WireMock.verify(1, getRequestedFor(urlEqualTo(GET_URL)));
+		verify(drcClient, times(12)).sendFdcReqToDrc(any());
+
+		verify(eventService, times(12)).logFdc(eq(EventType.SENT_TO_DRC), any(), any(), eq(MapperUtils.STATUS_CONFLICT_DUPLICATE_ID), any());
 		WireMock.verify(1, postRequestedFor(urlEqualTo(UPDATE_URL)));
 		verify(fdcMapperUtils,times(1)).generateFileXML(any(),any());
 	}

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/utils/ContributionsMapperUtilsTest.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/utils/ContributionsMapperUtilsTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatusCode;
 import uk.gov.justice.laa.crime.dces.integration.config.ApplicationTestBase;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.CONTRIBUTIONS;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.contributions.ContributionFile;
@@ -134,7 +135,7 @@ class ContributionsMapperUtilsTest extends ApplicationTestBase {
 
 	@Test
 	void testValidateDrcJsonResponse() {
-		int pseudoStatusCode = ContributionsMapperUtils.mapDRCJsonResponseToHttpStatus(null);
+		HttpStatusCode pseudoStatusCode = ContributionsMapperUtils.mapDRCJsonResponseToHttpStatus(null);
 		softly.assertThat(pseudoStatusCode).isEqualTo(STATUS_OK_INVALID);
 		pseudoStatusCode = ContributionsMapperUtils.mapDRCJsonResponseToHttpStatus("");
 		softly.assertThat(pseudoStatusCode).isEqualTo(STATUS_OK_INVALID);

--- a/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/utils/FdcMapperUtilsTests.java
+++ b/dces-drc-integration/src/test/java/uk/gov/justice/laa/crime/dces/integration/utils/FdcMapperUtilsTests.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatusCode;
 import uk.gov.justice.laa.crime.dces.integration.config.ApplicationTestBase;
 import uk.gov.justice.laa.crime.dces.integration.maatapi.model.fdc.FdcContributionEntry;
 import uk.gov.justice.laa.crime.dces.integration.model.generated.fdc.FdcFile.FdcList.Fdc;
@@ -75,7 +76,7 @@ class FdcMapperUtilsTests extends ApplicationTestBase {
 
 	@Test
 	void testValidateDrcJsonResponse() {
-		int pseudoStatusCode = FdcMapperUtils.mapDRCJsonResponseToHttpStatus(null);
+		HttpStatusCode pseudoStatusCode = FdcMapperUtils.mapDRCJsonResponseToHttpStatus(null);
 		softly.assertThat(pseudoStatusCode).isEqualTo(STATUS_OK_INVALID);
 		pseudoStatusCode = FdcMapperUtils.mapDRCJsonResponseToHttpStatus("");
 		softly.assertThat(pseudoStatusCode).isEqualTo(STATUS_OK_INVALID);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-710)

Changed logging of the DRC CONFLICT 409 http status, to it's own status code. To allow easy differentiation between it and generic CONFLICT results.
Refactor of the other custom status codes to HttpStatusCode since we don't do any processing/modification on it.

## Checklist

Before you ask people to review this PR:

- [ ] You have populated this PR ticket with relevant information.
- [ ] Tests should be passing: `./gradlew test`
- [ ] Has been deployed to DEV successfully, and Integration Tests have been successful. `./gradlew integrationTest`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
