### PR TITLE
Dces 714 force helm deployment refresh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,7 @@ commands:
           release-name: laa-dces-drc-integration
           values: ./helm_deploy/laa-dces-drc-integration/values-<< parameters.environment >>.yaml
           values-to-override: image.tag=${CIRCLE_SHA1},ingress.allowlist.monx=${CIDR_MONX},ingress.allowlist.laai=${CIDR_LAAI}
+          force: true
 
 # ------------------
 # JOBS


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-714)

We have experienced failing deployments because of vestigial settings (such as environment variables that depend on secrets) not being deleted when we deploy new versions.

To avoid this, added force:true as a parameter to helm upgrade command so that the existing settings are removed and recreated (if needed) by every deployment. 

## Checklist

Before you ask people to review this PR:

- [ ] You have populated this PR ticket with relevant information.
- [ ] Tests should be passing: `./gradlew test`
- [ ] Has been deployed to DEV successfully, and Integration Tests have been successful. `./gradlew integrationTest`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
