### PR TITLE
DCES-706 Change ingress enabled to enable.mtls/nonMtls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,13 @@ This is a Java based Spring Boot application hosted on [MOJ Cloud Platform](http
 
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-### Decrypting docker-compose.override.yml
+### Modifying docker-compose.override.yml
 
-The `docker-compose.override.yml` is encrypted using [git-crypt](https://github.com/AGWA/git-crypt).
+The `docker-compose.override.yml` and some other files used to be encrypted using `git-crypt`.
+However, the use of `git-crypt` is now deprecated and has since been removed from this repository.
 
-To run the app locally you need to be able to decrypt this file.
-
-You will first need to create a GPG key. See [Create a GPG Key](https://docs.publishing.service.gov.uk/manual/create-a-gpg-key.html) for details on how to do this with `GPGTools` (GUI) or `gpg` (command line).
-You can install either from a terminal or just download the UI version.
-
-```
-brew update
-brew install gpg
-brew install git-crypt
-```
-
-Once you have done this, a team member who already has access can add your key by running `git-crypt add-gpg-user USER_ID`\* and creating a pull request to this repo.
-
-Once this has been merged you can decrypt your local copy of the repository by running `git-crypt unlock`.
-
-\*`USER_ID` can be your key ID, a full fingerprint, an email address, or anything else that uniquely identifies a public key to GPG (see "HOW TO SPECIFY A USER ID" in the gpg man page).
-The apps should then startup cleanly if you run
+If you make local changes to `docker-compose.override.yml`, be sure not to commit them.
+In fact, it may make sense to remove `docker-compose.override.yml` and add it to `.gitignore`.
 
 ### Application Set up
 

--- a/helm_deploy/laa-dces-drc-integration/templates/ingress-mTLS.yaml
+++ b/helm_deploy/laa-dces-drc-integration/templates/ingress-mTLS.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.privateIngress.enabled.mtls -}}
+{{- if .Values.privateIngress.enable.mtls -}}
 {{- $fullName := include "laa-dces-drc-integration.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/helm_deploy/laa-dces-drc-integration/templates/ingress.yaml
+++ b/helm_deploy/laa-dces-drc-integration/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.privateIngress.enabled.nonMtls -}}
+{{- if .Values.privateIngress.enable.nonMtls -}}
 {{- $fullName := include "laa-dces-drc-integration.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}


### PR DESCRIPTION
## What

[DCES-706](https://dsdmoj.atlassian.net/browse/DCES-706) Change ingress enabled to enable.mtls/nonMtls

So we can enable/disable the two ingress endpoints independently, without clashing with the previous `privateIngress.enabled` value. A corresponding change was made to all the AWS Secrets to revert back so that `privateIngress.enabled` has a value, and to add the new values `privateIngress.enable.mtls` and `privateIngress.enable.nonMtls`, which will be used in future.

At some future time, when this change has been promoted into all environments, then the value `privateIngress.enabled` can be removed from the AWS Secrets.

## Checklist

Before you ask people to review this PR:

- [X] You have populated this PR ticket with relevant information.
- [X] Tests should be passing: `./gradlew test`
- [X] Has been deployed to DEV successfully, and Integration Tests have been successful. `./gradlew integrationTest`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.


[DCES-706]: https://dsdmoj.atlassian.net/browse/DCES-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ